### PR TITLE
Fix Mihon extension language selection

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/model/MangaSource.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/model/MangaSource.kt
@@ -3,7 +3,11 @@ package org.koitharu.kotatsu.core.model
 import android.content.Context
 import android.os.Build
 import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.RelativeSizeSpan
 import android.text.style.ImageSpan
+import android.text.style.StyleSpan
+import android.graphics.Typeface
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -34,11 +38,12 @@ fun MangaSource(name: String?): MangaSource {
 		LocalMangaSource.name -> return LocalMangaSource
 	}
 	if (name.startsWith("MIHON_")) {
+		MihonExtensionManager.getByName(name)?.let { return it }
 		val sourceId = name.removePrefix("MIHON_").substringBefore(':').toLongOrNull()
 		if (sourceId != null) {
 			return MihonExtensionManager.getById(sourceId) ?: MissingMangaSource(name)
 		}
-		return MihonExtensionManager.getByName(name) ?: MissingMangaSource(name)
+		return MissingMangaSource(name)
 	}
 	return MissingMangaSource(name)
 }
@@ -106,6 +111,11 @@ fun MangaSource.getTitle(context: Context): String = when (val source = unwrap()
 	else -> context.getString(R.string.unknown)
 }
 
+fun MangaSource.getTitleWithInlineLanguage(context: Context): CharSequence = when (val source = unwrap()) {
+	is MihonMangaSource -> source.displayNameWithInlineLanguage()
+	else -> getTitle(context)
+}
+
 fun MangaSource.isExternalSource(): Boolean = when (val source = unwrap()) {
 	is MihonMangaSource -> true
 	is MissingMangaSource -> source.name.startsWith("MIHON_")
@@ -147,6 +157,19 @@ private fun MissingMangaSource.cachedDisplayNameOrNull(): String? {
 	if (!name.startsWith("MIHON_")) return null
 	val parts = name.removePrefix("MIHON_").split(':', limit = 2)
 	return parts.getOrNull(1)?.ifBlank { null }
+}
+
+private fun MihonMangaSource.displayNameWithInlineLanguage(): CharSequence {
+	if (!hasLanguageSuffix) {
+		return displayNameWithoutLanguage
+	}
+	val title = SpannableStringBuilder(displayNameWithoutLanguage)
+	title.append(' ')
+	val langStart = title.length
+	title.append(languageDisplayName)
+	title.setSpan(RelativeSizeSpan(0.72f), langStart, title.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+	title.setSpan(StyleSpan(Typeface.NORMAL), langStart, title.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+	return title
 }
 
 fun SpannableStringBuilder.appendIcon(textView: TextView, @DrawableRes resId: Int): SpannableStringBuilder {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
@@ -836,6 +836,7 @@ class AppRouter private constructor(
         const val KEY_SORT_ORDER = "sort_order"
         const val KEY_SOURCE_CATALOG_EXTERNAL_ONLY = "source_catalog_external_only"
         const val KEY_SOURCE = "source"
+        const val KEY_RETURN_TO_SOURCE_ON_LANGUAGE_CHANGE = "return_to_source_on_language_change"
         const val KEY_TAB = "tab"
         const val KEY_TITLE = "title"
         const val KEY_URL = "url"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -398,7 +398,7 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		}
 
 	var sourcesSortOrder: SourcesSortOrder
-		get() = prefs.getEnumValue(KEY_SOURCES_ORDER, SourcesSortOrder.LAST_USED)
+		get() = prefs.getEnumValue(KEY_SOURCES_ORDER, SourcesSortOrder.ALPHABETIC)
 		set(value) = prefs.edit { putEnumValue(KEY_SOURCES_ORDER, value) }
 
 	var isSourcesGridMode: Boolean
@@ -434,6 +434,20 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		val key = "$pkgName:$lang"
 		if (enabled) current.remove(key) else current.add(key)
 		mihonPerExtDisabledLangs = current
+	}
+
+	var mihonSelectedLanguages: Set<String>
+		get() = prefs.getStringSet(KEY_MIHON_SELECTED_LANGUAGES, emptySet()).orEmpty()
+		set(value) = prefs.edit { putStringSet(KEY_MIHON_SELECTED_LANGUAGES, value) }
+
+	fun getMihonSelectedLanguage(pkgName: String): String? {
+		val prefix = "$pkgName:"
+		return mihonSelectedLanguages.firstOrNull { it.startsWith(prefix) }?.substringAfter(':')
+	}
+
+	fun setMihonSelectedLanguage(pkgName: String, lang: String) {
+		val prefix = "$pkgName:"
+		mihonSelectedLanguages = mihonSelectedLanguages.filterNotTo(HashSet()) { it.startsWith(prefix) } + "$pkgName:$lang"
 	}
 
 	var externalExtensionsRepoUrl: String?
@@ -931,6 +945,7 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_SOURCES_PREFERRED_LANGUAGES = "sources_preferred_languages"
 		const val KEY_MIHON_PREFERRED_LANGUAGES = "mihon_preferred_languages"
 		const val KEY_MIHON_PER_EXT_DISABLED_LANGS = "mihon_per_ext_disabled_langs"
+		const val KEY_MIHON_SELECTED_LANGUAGES = "mihon_selected_languages"
 		const val KEY_EXTERNAL_EXTENSIONS_REPO_URL = "external_extensions_repo_url"
 		const val KEY_BACKUP_INCLUDE_LIBRARY = "backup_include_library"
 		const val KEY_BACKUP_INCLUDE_APP_SETTINGS = "backup_include_app_settings"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/explore/data/MangaSourcesRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/explore/data/MangaSourcesRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import androidx.core.os.LocaleListCompat
 import org.koitharu.kotatsu.core.LocalizedAppContext
 import org.koitharu.kotatsu.core.model.MangaSourceInfo
 import org.koitharu.kotatsu.core.model.getTitle
@@ -16,6 +17,7 @@ import org.koitharu.kotatsu.core.ui.util.ReversibleHandle
 import org.koitharu.kotatsu.mihon.MihonExtensionManager
 import org.koitharu.kotatsu.mihon.model.MihonMangaSource
 import org.koitharu.kotatsu.parsers.model.MangaSource
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,8 +35,7 @@ class MangaSourcesRepository @Inject constructor(
 		return buildSortedSourceInfoList(getMihonSources()).map { it.mangaSource }
 	}
 
-	/** All installed sources including those disabled via per-extension language toggles
-	 *  (still respects the NSFW filter). Used by suggestions when "include disabled sources" is on. */
+	/** All installed sources, including non-selected languages, while still respecting the NSFW filter. */
 	fun getAllSources(): List<MangaSource> {
 		return buildSortedSourceInfoList(getAllMihonSources()).map { it.mangaSource }
 	}
@@ -199,14 +200,32 @@ class MangaSourcesRepository @Inject constructor(
 		val manager = mihonExtensionManager ?: return emptyList()
 		manager.initialize()
 		val sources = manager.getMihonMangaSources()
-		val preferredLangs = settings.mihonPreferredLanguages
-		val disabledLangs = settings.mihonPerExtDisabledLangs
 		val hideNsfw = settings.isNsfwContentDisabled
-		return sources.filter { source ->
-			val isPreferredLang = preferredLangs.isEmpty() || source.language in preferredLangs
-			val isEnabled = "${source.pkgName}:${source.language}" !in disabledLangs
-			val isNsfwOk = !hideNsfw || !source.isNsfw
-			isPreferredLang && isEnabled && isNsfwOk
+		return sources
+			.filter { source -> !hideNsfw || !source.isNsfw }
+			.groupBy { it.pkgName }
+			.values
+			.mapNotNull(::selectSourceForPackage)
+	}
+
+	private fun selectSourceForPackage(sources: List<MihonMangaSource>): MihonMangaSource? {
+		if (sources.isEmpty()) return null
+		val pkgName = sources.first().pkgName
+		val selectedLang = settings.getMihonSelectedLanguage(pkgName)
+		if (selectedLang != null) {
+			sources.firstOrNull { it.language == selectedLang }?.let { return it }
+		}
+		val legacyEnabledLangs = sources
+			.filter { settings.isMihonSourceLangEnabled(pkgName, it.language) }
+			.mapTo(HashSet()) { it.language }
+		if (legacyEnabledLangs.size == 1) {
+			sources.firstOrNull { it.language in legacyEnabledLangs }?.let {
+				settings.setMihonSelectedLanguage(pkgName, it.language)
+				return it
+			}
+		}
+		return sources.pickByPreferredLanguage(getMihonLanguageCandidates())?.also {
+			settings.setMihonSelectedLanguage(pkgName, it.language)
 		}
 	}
 
@@ -226,10 +245,10 @@ class MangaSourcesRepository @Inject constructor(
 		return combine(
 			manager.installedExtensions,
 			manager.isLoading,
-			settings.observeAsFlow(AppSettings.KEY_MIHON_PREFERRED_LANGUAGES) { mihonPreferredLanguages },
 			settings.observeAsFlow(AppSettings.KEY_MIHON_PER_EXT_DISABLED_LANGS) { mihonPerExtDisabledLangs },
+			settings.observeAsFlow(AppSettings.KEY_MIHON_SELECTED_LANGUAGES) { mihonSelectedLanguages },
 			settings.observeAsFlow(AppSettings.KEY_DISABLE_NSFW) { isNsfwContentDisabled },
-		) { _: Any?, _: Any?, _: Any?, _: Any?, _: Any? ->
+		) {
 			getMihonSources()
 		}.distinctUntilChanged()
 	}
@@ -260,4 +279,23 @@ class MangaSourcesRepository @Inject constructor(
 		private const val KEY_PINNED_ORDER = "pinned_order"
 		private const val PIN_SEPARATOR = "\n"
 	}
+}
+
+fun List<MihonMangaSource>.pickByPreferredLanguage(languageCandidates: Collection<String>): MihonMangaSource? {
+	if (isEmpty()) return null
+	val byLanguage = associateBy { it.language.lowercase(Locale.ROOT) }
+	for (candidate in languageCandidates) {
+		byLanguage[candidate.lowercase(Locale.ROOT)]?.let { return it }
+	}
+	return byLanguage["en"] ?: first()
+}
+
+fun getMihonLanguageCandidates(localeList: LocaleListCompat = LocaleListCompat.getAdjustedDefault()): List<String> {
+	val result = LinkedHashSet<String>()
+	for (i in 0 until localeList.size()) {
+		val locale = localeList.get(i) ?: continue
+		result += locale.toLanguageTag()
+		result += locale.language
+	}
+	return result.toList()
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/ExploreViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/ExploreViewModel.kt
@@ -29,6 +29,7 @@ import org.koitharu.kotatsu.explore.ui.model.ExploreButtons
 import org.koitharu.kotatsu.explore.ui.model.MangaSourceItem
 import org.koitharu.kotatsu.explore.ui.model.RecommendationsItem
 import org.koitharu.kotatsu.list.ui.model.EmptyHint
+import org.koitharu.kotatsu.list.ui.model.InfoModel
 import org.koitharu.kotatsu.list.ui.model.ListHeader
 import org.koitharu.kotatsu.list.ui.model.ListModel
 import org.koitharu.kotatsu.list.ui.model.LoadingState
@@ -153,7 +154,7 @@ class ExploreViewModel @Inject constructor(
 		isGrid: Boolean,
 		randomLoading: Boolean,
 	): List<ListModel> {
-		val result = ArrayList<ListModel>(sources.size + 3)
+		val result = ArrayList<ListModel>(sources.size + 4)
 		result += ExploreButtons(randomLoading)
 		if (recommendation.isNotEmpty()) {
 			result += ListHeader(R.string.suggestions, R.string.more, R.id.nav_suggestions)
@@ -173,6 +174,14 @@ class ExploreViewModel @Inject constructor(
 				textPrimary = R.string.no_external_source_installed,
 				textSecondary = R.string.manage_manga_extensions_from_settings_icon,
 				actionStringRes = NO_ACTION_STRING_RES,
+			)
+		}
+		if (sources.isNotEmpty()) {
+			result += InfoModel(
+				key = KEY_EXTENSION_LANGUAGE_NOTE,
+				title = R.string.languages,
+				text = R.string.extension_language_settings_note,
+				icon = R.drawable.ic_language,
 			)
 		}
 		return result
@@ -205,6 +214,7 @@ class ExploreViewModel @Inject constructor(
 	companion object {
 
 		private const val TIP_SUGGESTIONS = "suggestions"
+		private const val KEY_EXTENSION_LANGUAGE_NOTE = "extension_language_note"
 		private const val SUGGESTIONS_COUNT = 8
 		private const val NO_ACTION_STRING_RES = 0
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapter.kt
@@ -5,6 +5,7 @@ import org.koitharu.kotatsu.core.ui.list.OnListItemClickListener
 import org.koitharu.kotatsu.explore.ui.model.MangaSourceItem
 import org.koitharu.kotatsu.list.ui.adapter.ListItemType
 import org.koitharu.kotatsu.list.ui.adapter.emptyHintAD
+import org.koitharu.kotatsu.list.ui.adapter.infoAD
 import org.koitharu.kotatsu.list.ui.adapter.listHeaderAD
 import org.koitharu.kotatsu.list.ui.adapter.loadingStateAD
 import org.koitharu.kotatsu.list.ui.model.ListModel
@@ -25,6 +26,7 @@ class ExploreAdapter(
 		addDelegate(ListItemType.HEADER, listHeaderAD(listener))
 		addDelegate(ListItemType.EXPLORE_SOURCE_LIST, exploreSourceListItemAD(clickListener))
 		addDelegate(ListItemType.EXPLORE_SOURCE_GRID, exploreSourceGridItemAD(clickListener))
+		addDelegate(ListItemType.INFO, infoAD())
 		addDelegate(ListItemType.HINT_EMPTY, emptyHintAD(listener))
 		addDelegate(ListItemType.STATE_LOADING, loadingStateAD())
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapterDelegates.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapterDelegates.kt
@@ -1,5 +1,6 @@
 package org.koitharu.kotatsu.explore.ui.adapter
 
+import android.content.Context
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.text.bold
@@ -14,6 +15,7 @@ import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.model.getSummary
 import org.koitharu.kotatsu.core.model.getTitle
 import org.koitharu.kotatsu.core.model.isExternalSource
+import org.koitharu.kotatsu.core.model.unwrap
 import org.koitharu.kotatsu.core.ui.BaseListAdapter
 import org.koitharu.kotatsu.core.ui.list.AdapterDelegateClickListenerAdapter
 import org.koitharu.kotatsu.core.ui.list.OnListItemClickListener
@@ -31,6 +33,7 @@ import org.koitharu.kotatsu.explore.ui.model.RecommendationsItem
 import org.koitharu.kotatsu.list.ui.adapter.ListItemType
 import org.koitharu.kotatsu.list.ui.model.ListModel
 import org.koitharu.kotatsu.list.ui.model.MangaCompactListModel
+import org.koitharu.kotatsu.mihon.model.MihonMangaSource
 import org.koitharu.kotatsu.parsers.model.Manga
 
 fun exploreButtonsAD(
@@ -118,7 +121,7 @@ fun exploreSourceListItemAD(
 	val iconPinned = ContextCompat.getDrawable(context, R.drawable.ic_pin_small)
 
 	bind {
-		binding.textViewTitle.text = item.source.getTitle(context)
+		binding.textViewTitle.text = item.source.getExploreTitle(context)
 		binding.textViewTitle.drawableStart = if (item.source.isPinned) iconPinned else null
 		binding.textViewSubtitle.text = item.source.getSummary(context)
 		binding.imageViewIcon.applyExternalSourceStyle(item.source.mangaSource.isExternalSource())
@@ -143,7 +146,7 @@ fun exploreSourceGridItemAD(
 	val iconPinned = ContextCompat.getDrawable(context, R.drawable.ic_pin_small)
 
 	bind {
-		val title = item.source.getTitle(context)
+		val title = item.source.getExploreTitle(context)
 		itemView.setTooltipCompat(
 			buildSpannedString {
 				bold {
@@ -157,5 +160,12 @@ fun exploreSourceGridItemAD(
 		binding.textViewTitle.drawableStart = if (item.source.isPinned) iconPinned else null
 		binding.imageViewIcon.applyExternalSourceStyle(item.source.mangaSource.isExternalSource())
 		binding.imageViewIcon.setImageAsync(item.source)
+	}
+}
+
+private fun org.koitharu.kotatsu.core.model.MangaSourceInfo.getExploreTitle(context: Context): String {
+	return when (val source = mangaSource.unwrap()) {
+		is MihonMangaSource -> source.displayNameWithoutLanguage
+		else -> getTitle(context)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/MihonExtensionManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/MihonExtensionManager.kt
@@ -114,9 +114,15 @@ class MihonExtensionManager @Inject constructor(
 	fun getMihonMangaSourceById(sourceId: Long): MihonMangaSource? = facade.getWrappedSourceById(sourceId)
 
 	fun getMihonMangaSourceByName(name: String): MihonMangaSource? {
-		val exact = facade.getWrappedSourceByName(name)
-		if (exact != null) return exact
-		val sourceId = name.removePrefix("MIHON_").substringBefore(':').toLongOrNull() ?: return null
+		if (!name.startsWith("MIHON_")) return null
+		val raw = name.removePrefix("MIHON_")
+		val sourceId = raw.substringBefore(':').toLongOrNull() ?: return null
+		val language = raw.substringAfter(':', missingDelimiterValue = "").ifBlank { null }
+		if (language != null) {
+			getMihonMangaSources().firstOrNull { it.sourceId == sourceId && it.language == language }?.let {
+				return it
+			}
+		}
 		return facade.getWrappedSourceById(sourceId)
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonMangaSource.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonMangaSource.kt
@@ -11,14 +11,20 @@ data class MihonMangaSource(
 	val hasLanguageSuffix: Boolean = false,
 ) : MangaSource {
 	override val name: String
-		get() = "MIHON_${catalogueSource.id}"
+		get() = "MIHON_${catalogueSource.id}:$language"
 
 	val displayName: String
 		get() = if (hasLanguageSuffix) {
-			"${catalogueSource.name} (${getExternalExtensionLanguageDisplayName(language)})"
+			"$displayNameWithoutLanguage ($languageDisplayName)"
 		} else {
-			catalogueSource.name
+			displayNameWithoutLanguage
 		}
+
+	val displayNameWithoutLanguage: String
+		get() = catalogueSource.name
+
+	val languageDisplayName: String
+		get() = getExternalExtensionLanguageDisplayName(language)
 
 	val language: String
 		get() = catalogueSource.lang
@@ -31,13 +37,22 @@ data class MihonMangaSource(
 
 	override fun equals(other: Any?): Boolean {
 		if (this === other) return true
-		if (other !is MangaSource) return false
-		val raw = other.name.removePrefix("MIHON_").substringBefore(':')
-		return raw.toLongOrNull() == sourceId
+		return when (other) {
+			is MihonMangaSource -> sourceId == other.sourceId && language == other.language
+			is MangaSource -> {
+				val raw = other.name.removePrefix("MIHON_")
+				val otherId = raw.substringBefore(':').toLongOrNull() ?: return false
+				val otherLanguage = raw.substringAfter(':', missingDelimiterValue = "")
+				sourceId == otherId && (otherLanguage.isEmpty() || language == otherLanguage)
+			}
+			else -> false
+		}
 	}
 
 	override fun hashCode(): Int {
-		return sourceId.hashCode()
+		var result = sourceId.hashCode()
+		result = 31 * result + language.hashCode()
+		return result
 	}
 
 	override fun toString(): String {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/remotelist/ui/RemoteListFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/remotelist/ui/RemoteListFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import com.google.android.material.snackbar.Snackbar
@@ -13,6 +14,8 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.drop
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.model.getTitle
+import org.koitharu.kotatsu.core.model.MangaSource as mangaSourceOf
+import org.koitharu.kotatsu.core.nav.AppRouter
 import org.koitharu.kotatsu.core.nav.router
 import org.koitharu.kotatsu.core.ui.list.ListSelectionController
 import org.koitharu.kotatsu.core.ui.util.MenuInvalidator
@@ -27,11 +30,16 @@ import org.koitharu.kotatsu.filter.ui.FilterCoordinator
 import org.koitharu.kotatsu.list.ui.MangaListFragment
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.search.domain.SearchKind
+import org.koitharu.kotatsu.search.ui.MangaListActivity
 
 @AndroidEntryPoint
 class RemoteListFragment : MangaListFragment(), FilterCoordinator.Owner, View.OnClickListener {
 
     override val viewModel by viewModels<RemoteListViewModel>()
+    private val sourceSettingsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val sourceName = result.data?.getStringExtra(AppRouter.KEY_SOURCE) ?: return@registerForActivityResult
+        (activity as? MangaListActivity)?.switchSource(mangaSourceOf(sourceName))
+    }
 
     override val filterCoordinator: FilterCoordinator
         get() = viewModel.filterCoordinator
@@ -121,7 +129,10 @@ class RemoteListFragment : MangaListFragment(), FilterCoordinator.Owner, View.On
 
         override fun onMenuItemSelected(menuItem: MenuItem): Boolean = when (menuItem.itemId) {
             R.id.action_source_settings -> {
-                router.openSourceSettings(viewModel.source)
+                sourceSettingsLauncher.launch(
+                    AppRouter.sourceSettingsIntent(requireContext(), viewModel.source)
+                        .putExtra(AppRouter.KEY_RETURN_TO_SOURCE_ON_LANGUAGE_CHANGE, true),
+                )
                 true
             }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/MangaListActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/search/ui/MangaListActivity.kt
@@ -21,10 +21,11 @@ import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.model.LocalMangaSource
 import org.koitharu.kotatsu.core.model.MangaSource
 import org.koitharu.kotatsu.core.model.getSummary
-import org.koitharu.kotatsu.core.model.getTitle
+import org.koitharu.kotatsu.core.model.getTitleWithInlineLanguage
 import org.koitharu.kotatsu.core.model.isNsfw
 import org.koitharu.kotatsu.core.model.parcelable.ParcelableManga
 import org.koitharu.kotatsu.core.model.parcelable.ParcelableMangaListFilter
+import org.koitharu.kotatsu.core.model.unwrap
 import org.koitharu.kotatsu.core.nav.AppRouter
 import org.koitharu.kotatsu.core.nav.router
 import org.koitharu.kotatsu.core.ui.BaseActivity
@@ -46,6 +47,7 @@ import org.koitharu.kotatsu.filter.ui.sheet.FilterSheetFragment
 import org.koitharu.kotatsu.list.ui.preview.PreviewFragment
 import org.koitharu.kotatsu.local.ui.LocalListFragment
 import org.koitharu.kotatsu.main.ui.owners.AppBarOwner
+import org.koitharu.kotatsu.mihon.model.MihonMangaSource
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaListFilter
 import org.koitharu.kotatsu.parsers.model.MangaSource
@@ -67,7 +69,7 @@ class MangaListActivity :
 	override val filterCoordinator: FilterCoordinator
 		get() = checkNotNull(findFilterOwner()) {
 			"Cannot find FilterCoordinator.Owner fragment in ${supportFragmentManager.fragments}"
-		}.filterCoordinator
+	}.filterCoordinator
 
 	private lateinit var source: MangaSource
 
@@ -85,7 +87,7 @@ class MangaListActivity :
 			viewBinding.appbar.addOnOffsetChangedListener(this)
 		}
 		viewBinding.buttonOrder?.setOnClickListener(this)
-		title = source.getTitle(this)
+		updateSourceTitle()
 		initList(source, filter, sortOrder)
 	}
 
@@ -131,10 +133,10 @@ class MangaListActivity :
 
 	fun hidePreview() = setSideFragment(FilterSheetFragment::class.java, null)
 
-	private fun initList(source: MangaSource, filter: MangaListFilter?, sortOrder: SortOrder?) {
+	private fun initList(source: MangaSource, filter: MangaListFilter?, sortOrder: SortOrder?, forceReplace: Boolean = false) {
 		val fm = supportFragmentManager
 		val existingFragment = fm.findFragmentById(R.id.container)
-		if (existingFragment is FilterCoordinator.Owner) {
+		if (!forceReplace && existingFragment is FilterCoordinator.Owner) {
 			initFilter(existingFragment)
 		} else {
 			fm.commit {
@@ -213,5 +215,28 @@ class MangaListActivity :
 				filterOwner.filterCoordinator.setAdjusted(filter)
 			}
 		}
+	}
+
+	private fun shouldSwitchTo(nextSource: MangaSource): Boolean {
+		if (nextSource == source) {
+			return false
+		}
+		val currentMihon = source.unwrap() as? MihonMangaSource ?: return false
+		val nextMihon = nextSource.unwrap() as? MihonMangaSource ?: return false
+		return currentMihon.pkgName == nextMihon.pkgName
+	}
+
+	fun switchSource(nextSource: MangaSource) {
+		if (!shouldSwitchTo(nextSource)) {
+			return
+		}
+		source = nextSource
+		updateSourceTitle()
+		initList(source, filter = null, sortOrder = null, forceReplace = true)
+	}
+
+	private fun updateSourceTitle() {
+		title = source.getTitleWithInlineLanguage(this)
+		supportActionBar?.subtitle = null
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
@@ -106,6 +106,7 @@ class SettingsActivity :
 	}
 
 	fun setSectionTitle(title: CharSequence?) {
+		supportActionBar?.subtitle = null
 		viewBinding.textViewHeader?.apply {
 			textAndVisible = title
 		} ?: setTitle(title ?: getString(R.string.settings))
@@ -133,6 +134,17 @@ class SettingsActivity :
 			if (!isMasterDetails || (hasFragment && !isFromRoot)) {
 				addToBackStack(null)
 			}
+		}
+	}
+
+	fun replaceCurrentFragment(fragmentClass: Class<out Fragment>, args: Bundle?) {
+		viewModel.discardSearch()
+		val fragment = supportFragmentManager.fragmentFactory.instantiate(classLoader, fragmentClass.name).apply {
+			arguments = args
+		}
+		supportFragmentManager.commit {
+			setReorderingAllowed(true)
+			replace(R.id.container, fragment)
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/ExtensionsSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/ExtensionsSettingsFragment.kt
@@ -87,7 +87,7 @@ private fun ExtensionsScreen(
 		ctx.resources.getStringArray(R.array.incognito_nsfw_values).toList()
 	}
 
-	var sortOrder by rememberStringPref(AppSettings.KEY_SOURCES_ORDER, SourcesSortOrder.LAST_USED.name)
+	var sortOrder by rememberStringPref(AppSettings.KEY_SOURCES_ORDER, SourcesSortOrder.ALPHABETIC.name)
 	var grid by rememberBooleanPref(AppSettings.KEY_SOURCES_GRID, true)
 	var noNsfw by rememberBooleanPref(AppSettings.KEY_DISABLE_NSFW, false)
 	var tagsWarnings by rememberBooleanPref(AppSettings.KEY_TAGS_WARNINGS, true)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsFragment.kt
@@ -1,6 +1,7 @@
 package org.koitharu.kotatsu.settings.sources
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
@@ -17,18 +18,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.material3.RadioButton
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
-import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
@@ -42,7 +41,7 @@ import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.exceptions.resolve.SnackbarErrorObserver
-import org.koitharu.kotatsu.core.model.getTitle
+import org.koitharu.kotatsu.core.model.getTitleWithInlineLanguage
 import org.koitharu.kotatsu.core.nav.AppRouter
 import org.koitharu.kotatsu.core.nav.router
 import org.koitharu.kotatsu.core.parser.EmptyMangaRepository
@@ -53,6 +52,7 @@ import org.koitharu.kotatsu.core.util.ext.withArgs
 import org.koitharu.kotatsu.extensions.runtime.getExternalExtensionLanguageDisplayName
 import org.koitharu.kotatsu.mihon.MihonMangaRepository
 import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.settings.SettingsActivity
 import org.koitharu.kotatsu.settings.compose.ActionSettingsItem
 import org.koitharu.kotatsu.settings.compose.BaseComposeSettingsFragment
 import org.koitharu.kotatsu.settings.compose.DropSauceTheme
@@ -60,6 +60,7 @@ import org.koitharu.kotatsu.settings.compose.EditTextSettingsItem
 import org.koitharu.kotatsu.settings.compose.InfoSettingsItem
 import org.koitharu.kotatsu.settings.compose.ListSettingsItem
 import org.koitharu.kotatsu.settings.compose.MultiSelectSettingsItem
+import org.koitharu.kotatsu.settings.compose.SettingsItem
 import org.koitharu.kotatsu.settings.compose.SettingsGroup
 import org.koitharu.kotatsu.settings.compose.SettingsScaffold
 import org.koitharu.kotatsu.settings.compose.SwitchSettingsItem
@@ -74,9 +75,7 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 
 	override fun onResume() {
 		super.onResume()
-		val ctx = context ?: return
-		(activity as? org.koitharu.kotatsu.settings.SettingsActivity)
-			?.setSectionTitle(viewModel.source.getTitle(ctx))
+		updateSectionTitle()
 	}
 
 	override fun onCreateView(
@@ -93,7 +92,7 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 		val openBrowserUrl = ((repo as? MihonMangaRepository)?.mihonSource as? HttpSource)
 			?.baseUrl?.takeIf { it.isNotBlank() }
 		val uninstallPkg = (repo as? MihonMangaRepository)?.source?.pkgName
-		val languageToggles = buildLanguageToggles()
+		val languageSelection = buildLanguageSelection()
 
 		setContent {
 			DropSauceTheme {
@@ -101,7 +100,7 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 					sourcePrefs = sourcePrefs,
 					isValidSource = isValidSource,
 					mihonSections = mihonSections,
-					languageToggles = languageToggles,
+					languageSelection = languageSelection,
 					openBrowserUrl = openBrowserUrl,
 					uninstallPkg = uninstallPkg,
 					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
@@ -141,21 +140,45 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 		return buildSections(screen)
 	}
 
-	private fun buildLanguageToggles(): LanguageToggles? {
+	private fun buildLanguageSelection(): LanguageSelection? {
 		val repo = viewModel.repository as? MihonMangaRepository ?: return null
 		val pkgName = repo.source.pkgName
 		val siblings = viewModel.getSiblingMihonSources().sortedBy { it.language }
 		if (siblings.size <= 1) return null
 		val langs = siblings.map { it.language }
-		return LanguageToggles(
-			pkgName = pkgName,
+		return LanguageSelection(
 			languages = langs.map { lang ->
-				LanguageEntry(lang, getExternalExtensionLanguageDisplayName(lang))
+				val source = siblings.first { it.language == lang }
+				LanguageEntry(
+					lang = lang,
+					displayName = getExternalExtensionLanguageDisplayName(lang),
+					sourceName = source.name,
+				)
 			},
-			isLangEnabled = { lang -> viewModel.isMihonSourceLangEnabled(pkgName, lang) },
-			setLangEnabled = { lang, enabled -> viewModel.setMihonSourceLangEnabled(pkgName, lang, enabled) },
-			areAllEnabled = { viewModel.areAllMihonSourceLangsEnabled(pkgName, langs) },
-			setAllEnabled = { enabled -> viewModel.setMihonSourceLangsEnabled(pkgName, langs, enabled) },
+			selectedLanguage = viewModel.getSelectedMihonSourceLang(pkgName, langs),
+			setSelectedLanguage = ::setSelectedLanguage,
+		)
+	}
+
+	private fun updateSectionTitle() {
+		val ctx = context ?: return
+		(activity as? SettingsActivity)?.setSectionTitle(viewModel.source.getTitleWithInlineLanguage(ctx))
+	}
+
+	private fun setSelectedLanguage(entry: LanguageEntry) {
+		val repo = viewModel.repository as? MihonMangaRepository ?: return
+		viewModel.setSelectedMihonSourceLang(repo.source.pkgName, entry.lang)
+		if (entry.sourceName == viewModel.source.name) {
+			updateSectionTitle()
+			return
+		}
+		if (shouldReturnToSourceOnLanguageChange()) {
+			finishWithSelectedSource(entry.sourceName)
+			return
+		}
+		(activity as? SettingsActivity)?.replaceCurrentFragment(
+			SourceSettingsFragment::class.java,
+			newInstance(entry.sourceName).arguments,
 		)
 	}
 
@@ -173,6 +196,18 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 			Intent.ACTION_UNINSTALL_PACKAGE
 		}
 		startActivity(Intent(action, uri))
+	}
+
+	private fun finishWithSelectedSource(sourceName: String) {
+		requireActivity().setResult(
+			Activity.RESULT_OK,
+			Intent().putExtra(AppRouter.KEY_SOURCE, sourceName),
+		)
+		requireActivity().finish()
+	}
+
+	private fun shouldReturnToSourceOnLanguageChange(): Boolean {
+		return activity?.intent?.getBooleanExtra(AppRouter.KEY_RETURN_TO_SOURCE_ON_LANGUAGE_CHANGE, false) == true
 	}
 
 	/** Splits a populated [PreferenceScreen] into sections: each PreferenceCategory becomes its
@@ -206,23 +241,22 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 	}
 
 	companion object {
-		fun newInstance(source: MangaSource) = SourceSettingsFragment().withArgs(1) {
-			putString(AppRouter.KEY_SOURCE, source.name)
+		fun newInstance(source: MangaSource) = newInstance(source.name)
+
+		private fun newInstance(sourceName: String) = SourceSettingsFragment().withArgs(1) {
+			putString(AppRouter.KEY_SOURCE, sourceName)
 		}
 	}
 }
 
 private data class PreferenceSection(val title: String?, val preferences: List<Preference>)
 
-private class LanguageEntry(val lang: String, val displayName: String)
+private class LanguageEntry(val lang: String, val displayName: String, val sourceName: String)
 
-private class LanguageToggles(
-	val pkgName: String,
+private class LanguageSelection(
 	val languages: List<LanguageEntry>,
-	val isLangEnabled: (String) -> Boolean,
-	val setLangEnabled: (String, Boolean) -> Unit,
-	val areAllEnabled: () -> Boolean,
-	val setAllEnabled: (Boolean) -> Unit,
+	val selectedLanguage: String?,
+	val setSelectedLanguage: (LanguageEntry) -> Unit,
 )
 
 @Composable
@@ -230,7 +264,7 @@ private fun SourceSettingsScreen(
 	sourcePrefs: SharedPreferences,
 	isValidSource: Boolean,
 	mihonSections: List<PreferenceSection>,
-	languageToggles: LanguageToggles?,
+	languageSelection: LanguageSelection?,
 	openBrowserUrl: String?,
 	uninstallPkg: String?,
 	onBack: () -> Unit,
@@ -291,10 +325,10 @@ private fun SourceSettingsScreen(
 			}
 		}
 
-		if (languageToggles != null) {
+		if (languageSelection != null) {
 			item { Spacer(Modifier.height(8.dp).fillMaxWidth()) }
 			item {
-				LanguageTogglesGroup(languageToggles)
+				LanguageSelectionGroup(languageSelection)
 			}
 		}
 
@@ -414,37 +448,29 @@ private fun MihonPreferenceRow(
 }
 
 @Composable
-private fun LanguageTogglesGroup(toggles: LanguageToggles) {
-	// Single hoisted source of truth so toggling "All languages" updates every per-language
-	// switch immediately (previously each row kept its own state and only synced on re-entry).
-	val states = remember(toggles) {
-		mutableStateMapOf<String, Boolean>().apply {
-			toggles.languages.forEach { put(it.lang, toggles.isLangEnabled(it.lang)) }
-		}
+private fun LanguageSelectionGroup(selection: LanguageSelection) {
+	var selectedLang by remember(selection) {
+		mutableStateOf(selection.selectedLanguage ?: selection.languages.firstOrNull()?.lang)
 	}
-	val allEnabled = toggles.languages.isNotEmpty() && toggles.languages.all { states[it.lang] == true }
 	SettingsGroup(title = stringResource(R.string.languages)) {
-		item { pos ->
-			SwitchSettingsItem(
-				title = stringResource(R.string.all_languages),
-				checked = allEnabled,
-				onCheckedChange = { enabled ->
-					toggles.setAllEnabled(enabled)
-					toggles.languages.forEach { states[it.lang] = enabled }
-				},
-				shape = pos.shape,
-			)
-		}
-		toggles.languages.forEach { entry ->
+		selection.languages.forEach { entry ->
 			item { pos ->
-				SwitchSettingsItem(
+				SettingsItem(
 					title = entry.displayName,
-					checked = states[entry.lang] == true,
-					onCheckedChange = { value ->
-						toggles.setLangEnabled(entry.lang, value)
-						states[entry.lang] = value
+					onClick = {
+						selectedLang = entry.lang
+						selection.setSelectedLanguage(entry)
 					},
 					shape = pos.shape,
+					trailing = {
+						RadioButton(
+							selected = selectedLang == entry.lang,
+							onClick = {
+								selectedLang = entry.lang
+								selection.setSelectedLanguage(entry)
+							},
+						)
+					},
 				)
 			}
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsViewModel.kt
@@ -12,9 +12,11 @@ import org.koitharu.kotatsu.core.prefs.SourceSettings
 import org.koitharu.kotatsu.core.ui.BaseViewModel
 import org.koitharu.kotatsu.core.ui.util.ReversibleAction
 import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
+import org.koitharu.kotatsu.explore.data.getMihonLanguageCandidates
 import org.koitharu.kotatsu.mihon.MihonExtensionManager
 import org.koitharu.kotatsu.mihon.MihonMangaRepository
 import org.koitharu.kotatsu.mihon.model.MihonMangaSource
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -48,20 +50,24 @@ class SourceSettingsViewModel @Inject constructor(
 		return mihonExtensionManager.getMihonMangaSources().filter { it.pkgName == pkgName }
 	}
 
-	fun isMihonSourceLangEnabled(pkgName: String, lang: String): Boolean =
-		settings.isMihonSourceLangEnabled(pkgName, lang)
-
-	fun setMihonSourceLangEnabled(pkgName: String, lang: String, enabled: Boolean) {
-		settings.setMihonSourceLangEnabled(pkgName, lang, enabled)
-	}
-
-	fun setMihonSourceLangsEnabled(pkgName: String, langs: Collection<String>, enabled: Boolean) {
-		for (lang in langs) {
-			settings.setMihonSourceLangEnabled(pkgName, lang, enabled)
+	fun getSelectedMihonSourceLang(pkgName: String, langs: Collection<String>): String? {
+		val selected = settings.getMihonSelectedLanguage(pkgName)
+		if (selected != null && selected in langs) {
+			return selected
 		}
+		return langs.pickByPreferredLanguage(getMihonLanguageCandidates())
 	}
 
-	fun areAllMihonSourceLangsEnabled(pkgName: String, langs: Collection<String>): Boolean {
-		return langs.all { settings.isMihonSourceLangEnabled(pkgName, it) }
+	fun setSelectedMihonSourceLang(pkgName: String, lang: String) {
+		settings.setMihonSelectedLanguage(pkgName, lang)
 	}
+}
+
+private fun Collection<String>.pickByPreferredLanguage(languageCandidates: Collection<String>): String? {
+	if (isEmpty()) return null
+	val byLanguage = associateBy { it.lowercase(Locale.ROOT) }
+	for (candidate in languageCandidates) {
+		byLanguage[candidate.lowercase(Locale.ROOT)]?.let { return it }
+	}
+	return byLanguage["en"] ?: first()
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourceCatalogItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourceCatalogItem.kt
@@ -16,6 +16,7 @@ sealed interface SourceCatalogItem : ListModel {
 		val iconUrl: String? = null,
 		val sourceIconName: String? = null,
 		val sourceName: String? = null,
+		val selectedLanguage: String? = null,
 	) : SourceCatalogItem {
 
 		enum class Action(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourcesCatalogViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourcesCatalogViewModel.kt
@@ -18,15 +18,18 @@ import org.koitharu.kotatsu.core.prefs.observeAsFlow
 import org.koitharu.kotatsu.core.ui.BaseViewModel
 import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
 import org.koitharu.kotatsu.core.util.ext.call
-import org.koitharu.kotatsu.extensions.runtime.getExternalExtensionLanguageDisplayName
 import org.koitharu.kotatsu.explore.data.MangaSourcesRepository
+import org.koitharu.kotatsu.explore.data.getMihonLanguageCandidates
+import org.koitharu.kotatsu.explore.data.pickByPreferredLanguage
 import org.koitharu.kotatsu.list.ui.model.ListModel
 import org.koitharu.kotatsu.list.ui.model.LoadingState
 import org.koitharu.kotatsu.mihon.MihonExtensionLoader
+import org.koitharu.kotatsu.mihon.model.MihonMangaSource
 import org.koitharu.kotatsu.parsers.model.ContentType
 import java.util.Comparator
 import java.util.EnumSet
 import java.util.LinkedHashSet
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -74,7 +77,7 @@ class SourcesCatalogViewModel @Inject constructor(
 
 	val locales: StateFlow<Set<String?>> = combine(
 		appliedFilter,
-		mihonSources,
+		allMihonSources,
 		availableRepoEntries,
 	) { _, sources, repoEntries ->
 		val localeSet = LinkedHashSet<String?>()
@@ -181,10 +184,13 @@ class SourcesCatalogViewModel @Inject constructor(
 						onShowMessage.call(R.string.extensions_repo_required)
 						return@launchJob
 					}
-					val entry = getAvailableEntries(repoUrl, forceRefresh = false).firstOrNull { it.packageName == item.packageName } ?: run {
+					val entry = getAvailableEntries(repoUrl, forceRefresh = false)
+						.filter { it.packageName == item.packageName }
+						.pickByPreferredLanguage(item.selectedLanguage?.let(::listOf) ?: getMihonLanguageCandidates()) ?: run {
 						onShowMessage.call(R.string.nothing_found)
 						return@launchJob
 					}
+					entry.lang?.let { settings.setMihonSelectedLanguage(item.packageName, it) }
 					emitInstallRequests(
 						listOf(
 							InstallRequest(
@@ -213,6 +219,7 @@ class SourcesCatalogViewModel @Inject constructor(
 			}
 			emitInstallRequests(
 				updateEntries.map { entry ->
+					entry.lang?.let { settings.setMihonSelectedLanguage(entry.packageName, it) }
 					InstallRequest(
 						packageName = entry.packageName,
 						url = externalRepoRepository.resolveApkUrl(repoUrl, entry.apkName),
@@ -248,9 +255,11 @@ class SourcesCatalogViewModel @Inject constructor(
 	private suspend fun getUpdatableEntries(repoUrl: String): List<ExternalExtensionRepoEntry> {
 		val installedByPkg = mihonExtensionLoader.getInstalledExtensions(appContext).associateBy { it.pkgName }
 		return getAvailableEntries(repoUrl, forceRefresh = false)
-			.filter { entry ->
-				val local = installedByPkg[entry.packageName] ?: return@filter false
-				entry.versionCode > local.versionCode
+			.groupBy { it.packageName }
+			.mapNotNull { (_, entries) ->
+				val entry = entries.pickByPreferredLanguage(getMihonLanguageCandidates()) ?: return@mapNotNull null
+				val local = installedByPkg[entry.packageName] ?: return@mapNotNull null
+				entry.takeIf { it.versionCode > local.versionCode }
 			}
 			.sortedBy { it.name.lowercase() }
 	}
@@ -289,6 +298,7 @@ class SourcesCatalogViewModel @Inject constructor(
 		val locale = filter.locale
 		val q = query?.takeIf { it.isNotBlank() }
 		val inProgressPackages = installingPackages.value
+		val languageCandidates = getMihonLanguageCandidates()
 
 		for (local in installed.values) {
 			if (settings.isNsfwContentDisabled && local.isNsfw) continue
@@ -297,65 +307,55 @@ class SourcesCatalogViewModel @Inject constructor(
 			if (q != null && !local.appName.contains(q, ignoreCase = true) && !local.pkgName.contains(q, ignoreCase = true)) continue
 
 			val pkgSources = allInstalledSourcesByPkg[local.pkgName] ?: installedSourcesByPkg[local.pkgName]
-			val source = pkgSources?.firstOrNull { it.language == local.lang } ?: pkgSources?.firstOrNull()
-			val subtitle = buildString {
-				append(getExternalExtensionLanguageDisplayName(local.lang))
-				append(" • ")
-				append(local.versionName)
-				if (local.isNsfw) {
-					append(" • 18+")
-				}
-			}
+			val source = pkgSources.selectCatalogSource(local.pkgName, languageCandidates)
+			val displaySubtitle = buildExtensionSubtitle(local.versionName, local.isNsfw)
 			installedItems[local.pkgName] = SourceCatalogItem.Extension(
 				packageName = local.pkgName,
 				title = local.appName.removePrefix("Tachiyomi: ").trim(),
-				subtitle = subtitle,
+				subtitle = displaySubtitle,
 				action = SourceCatalogItem.Extension.Action.UNINSTALL,
 				isInProgress = local.pkgName in inProgressPackages,
 				iconUrl = null,
 				sourceIconName = source?.name,
 				sourceName = source?.name,
+				selectedLanguage = source?.language ?: local.lang,
 			)
 		}
 
-		for (entry in available) {
+		for ((packageName, packageEntries) in available.groupBy { it.packageName }) {
+			val entry = packageEntries.pickByPreferredLanguage(languageCandidates) ?: continue
 			if (settings.isNsfwContentDisabled && entry.isNsfw != 0) continue
-			if (locale != null && entry.lang != locale) continue
+			if (locale != null && packageEntries.none { it.lang == locale }) continue
 			if (q != null && !entry.name.contains(q, ignoreCase = true) && !entry.packageName.contains(q, ignoreCase = true)) continue
 
-			val local = installed[entry.packageName]
-			val pkgSources = allInstalledSourcesByPkg[entry.packageName] ?: installedSourcesByPkg[entry.packageName]
-			val source = pkgSources?.firstOrNull { it.language == entry.lang } ?: pkgSources?.firstOrNull()
-			val subtitle = buildString {
-				append(getExternalExtensionLanguageDisplayName(entry.lang.orEmpty()))
-				append(" • ")
-				append(entry.versionName)
-				if (entry.isNsfw != 0) {
-					append(" • 18+")
-				}
-			}
-			val iconUrl = repoUrl?.let { externalRepoRepository.resolveIconUrl(it, entry.packageName) }
+			val local = installed[packageName]
+			val pkgSources = allInstalledSourcesByPkg[packageName] ?: installedSourcesByPkg[packageName]
+			val source = pkgSources.selectCatalogSource(packageName, languageCandidates)
+			val displaySubtitle = buildExtensionSubtitle(entry.versionName, entry.isNsfw != 0)
+			val iconUrl = repoUrl?.let { externalRepoRepository.resolveIconUrl(it, packageName) }
 			when {
 				local == null -> availableItems += SourceCatalogItem.Extension(
-					packageName = entry.packageName,
+					packageName = packageName,
 					title = entry.name.removePrefix("Tachiyomi: ").trim(),
-					subtitle = subtitle,
+					subtitle = displaySubtitle,
 					action = SourceCatalogItem.Extension.Action.INSTALL,
-					isInProgress = entry.packageName in inProgressPackages,
+					isInProgress = packageName in inProgressPackages,
 					iconUrl = iconUrl,
 					sourceIconName = source?.name,
+					selectedLanguage = entry.lang,
 				)
 				entry.versionCode > local.versionCode -> pending += SourceCatalogItem.Extension(
-					packageName = entry.packageName,
+					packageName = packageName,
 					title = entry.name.removePrefix("Tachiyomi: ").trim(),
-					subtitle = subtitle,
+					subtitle = displaySubtitle,
 					action = SourceCatalogItem.Extension.Action.UPDATE,
-					isInProgress = entry.packageName in inProgressPackages,
+					isInProgress = packageName in inProgressPackages,
 					iconUrl = iconUrl,
 					sourceIconName = source?.name,
 					sourceName = source?.name,
+					selectedLanguage = source?.language ?: entry.lang,
 				).also {
-					packagesWithUpdates += entry.packageName
+					packagesWithUpdates += packageName
 				}
 				else -> Unit
 			}
@@ -416,6 +416,27 @@ class SourcesCatalogViewModel @Inject constructor(
 		}
 	}
 
+	private fun List<MihonMangaSource>?.selectCatalogSource(
+		packageName: String,
+		languageCandidates: Collection<String>,
+	): MihonMangaSource? {
+		val sources = this.orEmpty()
+		val selectedLang = settings.getMihonSelectedLanguage(packageName)
+		if (selectedLang != null) {
+			sources.firstOrNull { it.language == selectedLang }?.let { return it }
+		}
+		return sources.pickByPreferredLanguage(languageCandidates)
+	}
+
+	private fun buildExtensionSubtitle(versionName: String, isNsfw: Boolean): String {
+		return buildString {
+			append(versionName)
+			if (isNsfw) {
+				append(" - 18+")
+			}
+		}
+	}
+
 	private suspend fun getAvailableEntries(repoUrl: String, forceRefresh: Boolean): List<ExternalExtensionRepoEntry> {
 		return externalRepoRepository.getExtensions(repoUrl, forceRefresh)
 	}
@@ -438,4 +459,15 @@ class SourcesCatalogViewModel @Inject constructor(
 		val packageName: String,
 		val url: String,
 	)
+}
+
+private fun List<ExternalExtensionRepoEntry>.pickByPreferredLanguage(
+	languageCandidates: Collection<String>,
+): ExternalExtensionRepoEntry? {
+	if (isEmpty()) return null
+	val byLanguage = associateBy { it.lang.orEmpty().lowercase(Locale.ROOT) }
+	for (candidate in languageCandidates) {
+		byLanguage[candidate.lowercase(Locale.ROOT)]?.let { return it }
+	}
+	return byLanguage["en"] ?: first()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,6 +581,7 @@
     <string name="source_summary_pattern" translatable="false">%1$s, %2$s</string>
     <string name="sources_catalog">Sources catalog</string>
     <string name="extension_management">Extension manager</string>
+    <string name="extension_language_settings_note">Extension language can be changed from each extension\'s settings, if the extension supports it.</string>
     <string name="source_mode_mihon">External</string>
     <string name="source_enabled">Source enabled</string>
     <string name="no_manga_sources_catalog_text">There are no sources available in this section, or all of it might have been already added.\nStay tuned</string>


### PR DESCRIPTION
## Summary
- Collapse multi-language Mihon extensions into one Explore/catalog entity and persist one selected language per package.
- Add radio-button language selection in source settings and route selected-language changes back into the opened source screen.
- Keep Explore language labels hidden, show language inline in opened source titles, update the Explore note, and default extension sorting to Name.

## Verification
- .\gradlew.bat installDebug