### PR TITLE
Move Continue button into the floating navigation bar

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/widgets/FloatingBottomNavigationView.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/widgets/FloatingBottomNavigationView.kt
@@ -43,6 +43,8 @@ class FloatingBottomNavigationView @JvmOverloads constructor(
 	private val selectedIdState = MutableStateFlow(0)
 	private val labeledState = MutableStateFlow(true)
 	private val navColorsState = MutableStateFlow(readLegacyNavColors())
+	private val continueVisibleState = MutableStateFlow(false)
+	private var continueClickListener: (() -> Unit)? = null
 	private val sourceItems = mutableListOf<NavItem>()
 	private val hiddenIds = mutableSetOf<Int>()
 	private val badgeCounts = mutableMapOf<Int, Int>()
@@ -60,6 +62,7 @@ class FloatingBottomNavigationView @JvmOverloads constructor(
 				val selectedId by selectedIdState.collectAsState()
 				val labeled by labeledState.collectAsState()
 				val navColors by navColorsState.collectAsState()
+				val showContinue by continueVisibleState.collectAsState()
 				Box(
 					modifier = Modifier
 						.fillMaxWidth()
@@ -77,6 +80,8 @@ class FloatingBottomNavigationView @JvmOverloads constructor(
 							reselectedListener?.invoke(menuItem)
 						},
 						modifier = Modifier.wrapContentWidth(),
+						showContinue = showContinue,
+						onContinueClick = { continueClickListener?.invoke() },
 					)
 				}
 			}
@@ -133,6 +138,18 @@ class FloatingBottomNavigationView @JvmOverloads constructor(
 
 	fun setComposeLabeled(value: Boolean) {
 		labeledState.value = value
+	}
+
+	/**
+	 * Toggle the standalone circular "continue reading" button rendered next to the floating bar.
+	 * Has no effect in legacy navigation mode, where the Compose layer is hidden entirely.
+	 */
+	fun setContinueVisible(value: Boolean) {
+		continueVisibleState.value = value
+	}
+
+	fun setOnContinueClickListener(listener: (() -> Unit)?) {
+		continueClickListener = listener
 	}
 
 	fun setUseLegacyNavigation(value: Boolean) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -139,6 +139,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 
 		viewBinding.fab?.setOnClickListener(this)
 		viewBinding.navRail?.headerView?.findViewById<View>(R.id.railFab)?.setOnClickListener(this)
+		viewBinding.bottomNav?.setOnContinueClickListener { viewModel.openLastReader() }
 		viewBinding.buttonOverflow.setOnClickListener(this::showMainOverflowMenu)
 		viewBinding.buttonSettings.setOnClickListener {
 			router.openSettings()
@@ -184,6 +185,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 		viewModel.onError.observeEvent(this, SnackbarErrorObserver(viewBinding.container, null))
 		viewModel.isLoading.observe(this, this::onLoadingStateChanged)
 		viewModel.isResumeEnabled.observe(this, this::onResumeEnabledChanged)
+		settings.observe(AppSettings.KEY_NAV_LEGACY).observe(this) { adjustFabVisibility() }
 		viewModel.feedCounter.observe(this, ::onFeedCounterChanged)
 		viewModel.appUpdate.observe(this) { update ->
 			viewBinding.badgeSettingsUpdate.visibility = if (update != null) View.VISIBLE else View.GONE
@@ -425,16 +427,24 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 		} else {
 			navigationDelegate.primaryFragment
 		}
+		// When the modern floating bar is shown, the "continue reading" action lives on it as a
+		// standalone circular button (handled below), so it must never appear as a FAB. In legacy
+		// navigation mode — or on the tablet nav rail, which has no floating bar — it keeps the old
+		// behaviour of a FAB shown only inside the history tab.
+		val useFloatingContinue = viewBinding.bottomNav != null && !settings.isLegacyNavigationBar
 		val fabOwner = fragment as? MainFabOwner
 		if (fabOwner != null && !actionModeDelegate.isActionModeStarted && !isSearchOpened) {
 			showMainFab("owner:${fragment::class.java.name}") { fab ->
 				configureOwnerFab(fab, fabOwner)
 			}
-		} else if (isResumeEnabled && !actionModeDelegate.isActionModeStarted && !isSearchOpened && fragment is HistoryListFragment) {
+		} else if (!useFloatingContinue && isResumeEnabled && !actionModeDelegate.isActionModeStarted &&
+			!isSearchOpened && fragment is HistoryListFragment
+		) {
 			showMainFab("continue", ::configureContinueFab)
 		} else {
 			hideMainFab()
 		}
+		viewBinding.bottomNav?.setContinueVisible(useFloatingContinue && isResumeEnabled)
 	}
 
 	private fun showMainFab(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/nav/FloatingNavBar.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/nav/FloatingNavBar.kt
@@ -29,9 +29,15 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -40,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -90,38 +97,106 @@ fun FloatingNavBar(
 	onItemSelected: (Int) -> Unit,
 	onItemReselected: (Int) -> Unit,
 	modifier: Modifier = Modifier,
+	showContinue: Boolean = false,
+	onContinueClick: () -> Unit = {},
 ) {
 	if (items.isEmpty()) return
 	val cs = MaterialTheme.colorScheme
 	val barColor = Color(colors.container)
 
-	Surface(
-		modifier = modifier
-			.shadow(8.dp, RoundedCornerShape(50))
-			.wrapContentWidth(),
-		shape = RoundedCornerShape(50),
-		color = barColor,
-		contentColor = cs.onSurface,
+	Row(
+		modifier = modifier.wrapContentWidth(),
+		horizontalArrangement = Arrangement.spacedBy(8.dp),
+		verticalAlignment = Alignment.CenterVertically,
 	) {
-		Row(
+		Surface(
 			modifier = Modifier
-				.heightIn(min = 64.dp)
-				.padding(horizontal = 8.dp, vertical = 8.dp)
-				// Smoothly relayout siblings when one pill grows/shrinks horizontally.
-				.animateContentSize(animationSpec = FloatSpec_Size),
-			horizontalArrangement = Arrangement.spacedBy(4.dp),
-			verticalAlignment = Alignment.CenterVertically,
+				.shadow(8.dp, RoundedCornerShape(50))
+				.wrapContentWidth(),
+			shape = RoundedCornerShape(50),
+			color = barColor,
+			contentColor = cs.onSurface,
 		) {
-			items.forEach { item ->
-				FloatingNavItem(
-					item = item,
-					selected = item.id == selectedId,
-					showLabel = showLabels,
-					colors = colors,
-					onClick = {
-						if (item.id == selectedId) onItemReselected(item.id)
-						else onItemSelected(item.id)
-					},
+			Row(
+				modifier = Modifier
+					.heightIn(min = 64.dp)
+					.padding(horizontal = 8.dp, vertical = 8.dp)
+					// Smoothly relayout siblings when one pill grows/shrinks horizontally.
+					.animateContentSize(animationSpec = FloatSpec_Size),
+				horizontalArrangement = Arrangement.spacedBy(4.dp),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
+				items.forEach { item ->
+					FloatingNavItem(
+						item = item,
+						selected = item.id == selectedId,
+						showLabel = showLabels,
+						colors = colors,
+						onClick = {
+							if (item.id == selectedId) onItemReselected(item.id)
+							else onItemSelected(item.id)
+						},
+					)
+				}
+			}
+		}
+		// A standalone, pill-coloured circular "continue reading" button living next to the
+		// floating bar (like the search FAB in Tomato). It animates in/out smoothly and slides
+		// along as the bar resizes, so it always feels part of the same floating toolbar.
+		AnimatedVisibility(
+			visible = showContinue,
+			enter = fadeIn(animationSpec = FloatSpec_Float) +
+				expandHorizontally(animationSpec = FloatSpec_Size, expandFrom = Alignment.Start),
+			exit = fadeOut(animationSpec = FloatSpec_Float) +
+				shrinkHorizontally(animationSpec = FloatSpec_Size, shrinkTowards = Alignment.Start),
+		) {
+			FloatingContinueButton(
+				colors = colors,
+				onClick = onContinueClick,
+			)
+		}
+	}
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FloatingContinueButton(
+	colors: FloatingNavBarColors,
+	onClick: () -> Unit,
+) {
+	val container by animateColorAsState(
+		targetValue = Color(colors.selectedContainer),
+		animationSpec = FloatSpec_Color,
+		label = "continueContainer",
+	)
+	val content by animateColorAsState(
+		targetValue = Color(colors.selectedContent),
+		animationSpec = FloatSpec_Color,
+		label = "continueContent",
+	)
+	val label = stringResource(R.string.continue_reading)
+	val tooltipState = rememberTooltipState()
+	TooltipBox(
+		positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+		tooltip = { PlainTooltip { Text(label) } },
+		state = tooltipState,
+	) {
+		Surface(
+			onClick = onClick,
+			shape = CircleShape,
+			color = container,
+			contentColor = content,
+			shadowElevation = 8.dp,
+			modifier = Modifier
+				.size(56.dp)
+				.semantics { contentDescription = label },
+		) {
+			Box(contentAlignment = Alignment.Center) {
+				Icon(
+					painter = painterResource(R.drawable.ic_read),
+					contentDescription = null,
+					tint = content,
+					modifier = Modifier.size(24.dp),
 				)
 			}
 		}

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -26,13 +26,13 @@
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:layout_marginEnd="@dimen/grid_spacing"
-		android:minHeight="40dp"
+		android:minHeight="32dp"
 		android:minWidth="40dp"
 		android:visibility="invisible"
-		app:iconSize="22dp"
-		app:layout_constraintBottom_toBottomOf="parent"
+		app:iconSize="20dp"
+		app:layout_constraintBottom_toBottomOf="@id/textView_title"
 		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintTop_toTopOf="parent"
+		app:layout_constraintTop_toTopOf="@id/textView_title"
 		tools:text="@string/manage"
 		tools:visibility="visible" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="reader_settings">Reader settings</string>
     <string name="switch_pages">Switch pages</string>
     <string name="_continue">Continue</string>
+    <string name="continue_reading">Continue reading</string>
     <string name="error">Error</string>
     <string name="clear_thumbs_cache">Clear thumbnails cache</string>
     <string name="clear_search_history">Clear search history</string>


### PR DESCRIPTION
## What

Replaces the History-tab "Continue" FAB with a standalone **circular button attached to the right of the floating navigation pill**, present in every tab (not just History).

## Details

- **Always present** (when there's something to resume), regardless of the active tab — rendered as a sibling of the floating nav pill in the same Compose layer, so it slides/animates smoothly with the bar.
- **Icon only, no label.** Long-pressing it shows a "Continue reading" tooltip.
- **Filled with the selected-item indicator color** of the nav bar (`selectedContainer`), matching the currently selected menu pill rather than the old FAB color.
- **Honors the "Show floating Continue button" appearance setting** — it's driven by the same `isResumeEnabled` flow (which already accounts for that setting + incognito + available history), so turning the setting off removes it.
- **Legacy navigation bar** (and the tablet nav rail, which has no floating bar) keep the **previous behavior**: a Continue FAB shown only inside the History tab. The switch reacts at runtime when the legacy-nav setting is toggled.

## Implementation

- `FloatingNavBar.kt` — wraps the pill + a new `FloatingContinueButton` in a `Row`; the button uses Material3 `TooltipBox` for the long-press hint and animates in/out.
- `FloatingBottomNavigationView.kt` — exposes `setContinueVisible(...)` and `setOnContinueClickListener(...)`.
- `MainActivity.kt` — routes the continue action to the floating button for the modern bar, keeps the FAB path for legacy/rail, and re-evaluates on legacy-nav setting changes.
- Adds `continue_reading` string.

## Testing

A preview APK will be built by the PR Preview workflow attached to this PR.

https://claude.ai/code/session_01WhzAK9Donps4eE9zGnkxLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhzAK9Donps4eE9zGnkxLL)_