### PR TITLE
🧹 Refactor Fragment.container to check direct parent

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Fragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Fragment.kt
@@ -33,6 +33,4 @@ tailrec fun <T> Fragment.findParentCallback(cls: Class<T>): T? {
 }
 
 val Fragment.container: FragmentContainerView?
-	get() = view?.ancestors?.firstNotNullOfOrNull {
-		it as? FragmentContainerView // TODO check if direct parent
-	}
+	get() = view?.parent as? FragmentContainerView


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `Fragment.container` extension property incorrectly searched through all ancestors of the view to find a `FragmentContainerView`, which could return a higher-level container instead of the fragment's true container. This has been updated to check only the direct parent of the fragment's view.

💡 **Why:** How this improves maintainability
This change simplifies the logic (replacing a loop with a direct `parent` check) and corrects a known issue (noted by the previous `TODO check if direct parent`). It ensures the fragment is correctly mapped to its direct container, improving both correctness and performance.

✅ **Verification:** How you confirmed the change is safe
Ran the test suite using `./gradlew testDebugUnitTest` to ensure no functionality is broken by the refactoring.

✨ **Result:** The improvement achieved
A cleaner, faster, and more accurate container check.

---
*PR created automatically by Jules for task [18218094702578791320](https://jules.google.com/task/18218094702578791320) started by @HuzaifaKhalid1311*