### PR TITLE
Fix setDefaultValueCompat for MultiSelectListPreference

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Preferences.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Preferences.kt
@@ -19,7 +19,12 @@ fun ListPreference.setDefaultValueCompat(defaultValue: String) {
 }
 
 fun MultiSelectListPreference.setDefaultValueCompat(defaultValue: Set<String>) {
-	setDefaultValue(defaultValue) // FIXME not working
+	val prefs = sharedPreferences
+	if (prefs != null && !prefs.contains(key)) {
+		values = defaultValue
+	} else if (prefs == null) {
+		setDefaultValue(defaultValue)
+	}
 }
 
 fun <E : Enum<E>> SharedPreferences.getEnumValue(key: String, enumClass: Class<E>): E? {


### PR DESCRIPTION
Fix setDefaultValueCompat for MultiSelectListPreference

---
*PR created automatically by Jules for task [3688202677513984991](https://jules.google.com/task/3688202677513984991) started by @HuzaifaKhalid1311*