### PR TITLE
Refactor: Use OkHttp.initialize instead of direct PlatformRegistry assignment

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.platform.PlatformRegistry
+import okhttp3.OkHttp
 import org.acra.ACRA
 import org.acra.config.dialog
 import org.acra.data.StringFormat
@@ -71,7 +71,7 @@ open class BaseApp : Application(), Configuration.Provider {
 
 	override fun onCreate() {
 		super.onCreate()
-		PlatformRegistry.applicationContext = this // TODO replace with OkHttp.initialize
+		OkHttp.initialize(this)
 		if (ACRA.isACRASenderServiceProcess()) {
 			return
 		}


### PR DESCRIPTION
Fixes a TODO in `BaseApp.kt` by using `OkHttp.initialize` instead of directly setting the context on `PlatformRegistry`.

---
*PR created automatically by Jules for task [15189177624773617916](https://jules.google.com/task/15189177624773617916) started by @HuzaifaKhalid1311*