### PR TITLE
fix: improve missing chapter snackbar with remove from history action

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/ReadButtonDelegate.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/ReadButtonDelegate.kt
@@ -102,8 +102,9 @@ class ReadButtonDelegate(
 	private fun openReader(isIncognitoMode: Boolean) {
 		val manga = viewModel.getMangaOrNull() ?: return
 		if (viewModel.historyInfo.value.isChapterMissing) {
-			Snackbar.make(buttonRead, R.string.chapter_is_missing, Snackbar.LENGTH_SHORT)
-				.show() // TODO
+			Snackbar.make(buttonRead, R.string.chapter_is_missing, Snackbar.LENGTH_LONG)
+				.setAction(R.string.remove_from_history) { viewModel.removeFromHistory() }
+				.show()
 		} else {
 			val intentBuilder = ReaderIntent.Builder(context)
 				.manga(manga)


### PR DESCRIPTION
Resolves the TODO in `ReadButtonDelegate.kt` by adding an action to the Snackbar when a chapter is missing. It changes the duration to `Snackbar.LENGTH_LONG` to give users time to interact and sets the action to `viewModel.removeFromHistory()` with the string `R.string.remove_from_history`. This turns a passive notification into an actionable resolution.

---
*PR created automatically by Jules for task [3035725530369165814](https://jules.google.com/task/3035725530369165814) started by @HuzaifaKhalid1311*