### PR TITLE
Fix ListItemType.TIP spacing in TypedListSpacingDecoration

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/TypedListSpacingDecoration.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/TypedListSpacingDecoration.kt
@@ -67,12 +67,11 @@ class TypedListSpacingDecoration(
 			ListItemType.NAV_ITEM,
 			ListItemType.CHAPTER_LIST,
 			ListItemType.INFO,
+			ListItemType.TIP,
 			null,
 				-> outRect.set(0)
 
 			ListItemType.CHAPTER_GRID -> outRect.set(spacingSmall)
-
-			ListItemType.TIP -> outRect.set(0) // TODO
 		}
 		if (addHorizontalPadding && !itemType.isEdgeToEdge()) {
 			outRect.set(


### PR DESCRIPTION
Fix `ListItemType.TIP` spacing handling in `TypedListSpacingDecoration`. Grouped it logically with other elements requiring 0 padding and removed the `// TODO` note, verifying that the 0 padding is functionally correct given `TipView`'s existing margins.

---
*PR created automatically by Jules for task [7392649341522476238](https://jules.google.com/task/7392649341522476238) started by @HuzaifaKhalid1311*