### PR TITLE
Fix: Handle future dates correctly in calculateTimeAgo

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
@@ -16,7 +16,7 @@ fun calculateTimeAgo(instant: Instant, showMonths: Boolean = false): DateTimeAgo
 	val diffDays = localDate.until(now, ChronoUnit.DAYS)
 
 	return when {
-		diffDays < 0 -> null // in future, probably a bug, not supported
+		diffDays < 0 -> DateTimeAgo.JustNow
 		diffDays == 0L -> {
 			if (instant.until(Instant.now(), ChronoUnit.MINUTES) < 3) DateTimeAgo.JustNow
 			else DateTimeAgo.Today


### PR DESCRIPTION
Returns `DateTimeAgo.JustNow` for future dates instead of `null`. This prevents unexpected formatting issues or items disappearing when the server/client have slightly misaligned clocks or timezones.

---
*PR created automatically by Jules for task [13980118293951714940](https://jules.google.com/task/13980118293951714940) started by @HuzaifaKhalid1311*