### PR TITLE
Implement domains parsing in RulesList

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
@@ -50,6 +50,12 @@ sealed interface Rule {
 					return false
 				}
 			}
+			if (domainsNot != null && domainsNot.any { baseUrl.host == it || baseUrl.host.endsWith(".$it") }) {
+				return false
+			}
+			if (!domains.isNullOrEmpty() && !domains.any { baseUrl.host == it || baseUrl.host.endsWith(".$it") }) {
+				return false
+			}
 			// TODO check other modifiers
 			return true
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
@@ -73,19 +73,35 @@ class RulesList {
 		}
 		var script: Boolean? = null
 		var thirdParty: Boolean? = null
+		var domains: MutableSet<String>? = null
+		var domainsNot: MutableSet<String>? = null
 		options.split(',').forEach {
 			val isNot = it.startsWith('~')
-			when (it.removePrefix("~")) {
-				"script" -> script = !isNot
-				"third-party" -> thirdParty = !isNot
+			val item = it.removePrefix("~")
+			when {
+				item == "script" -> script = !isNot
+				item == "third-party" -> thirdParty = !isNot
+				item.startsWith("domain=") -> {
+					item.substringAfter("domain=").split('|').forEach { domain ->
+						val isDomainNot = domain.startsWith('~')
+						val actualDomain = domain.removePrefix("~")
+						if (isDomainNot) {
+							if (domainsNot == null) domainsNot = mutableSetOf()
+							domainsNot?.add(actualDomain)
+						} else {
+							if (domains == null) domains = mutableSetOf()
+							domains?.add(actualDomain)
+						}
+					}
+				}
 			}
 		}
 		return Rule.WithModifiers(
 			baseRule = this,
 			script = script,
 			thirdParty = thirdParty,
-			domains = null, //TODO
-			domainsNot = null, //TODO
+			domains = domains,
+			domainsNot = domainsNot,
 		)
 	}
 }


### PR DESCRIPTION
- Implement parsing logic for the `domain=` option in rule modifiers in `RulesList.kt`.
- Populate `domains` and `domainsNot` sets appropriately depending on whether the domain is prefixed with `~`.
- Enforce the domain exclusions and inclusions in `Rule.kt`'s `invoke` method. Matches subdomains correctly as well.

---
*PR created automatically by Jules for task [16930241523645903634](https://jules.google.com/task/16930241523645903634) started by @HuzaifaKhalid1311*