### PR TITLE
⚡ Performance: Optimize sequential db calls to use chunked IN sql query

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/MigrateUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/MigrateUseCase.kt
@@ -48,7 +48,7 @@ constructor(
 			val favoritesDao = database.getFavouritesDao()
 			val oldFavourites = favoritesDao.findAllRaw(oldDetails.id)
 			if (oldFavourites.isNotEmpty()) {
-				favoritesDao.delete(oldManga.id)
+				favoritesDao.delete(listOf(oldManga.id))
 				for (f in oldFavourites) {
 					val e =
 						f.copy(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
@@ -182,14 +182,14 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 
 	/** DELETE **/
 
-	suspend fun delete(mangaId: Long) = setDeletedAt(
-		mangaId = mangaId,
+	suspend fun delete(mangaIds: Collection<Long>) = setDeletedAt(
+		mangaIds = mangaIds,
 		deletedAt = System.currentTimeMillis(),
 	)
 
-	suspend fun delete(mangaId: Long, categoryId: Long) = setDeletedAt(
+	suspend fun delete(categoryId: Long, mangaIds: Collection<Long>) = setDeletedAt(
 		categoryId = categoryId,
-		mangaId = mangaId,
+		mangaIds = mangaIds,
 		deletedAt = System.currentTimeMillis(),
 	)
 
@@ -198,14 +198,14 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 		deletedAt = System.currentTimeMillis(),
 	)
 
-	suspend fun recover(mangaId: Long) = setDeletedAt(
-		mangaId = mangaId,
+	suspend fun recover(mangaIds: Collection<Long>) = setDeletedAt(
+		mangaIds = mangaIds,
 		deletedAt = 0L,
 	)
 
-	suspend fun recover(categoryId: Long, mangaId: Long) = setDeletedAt(
+	suspend fun recover(categoryId: Long, mangaIds: Collection<Long>) = setDeletedAt(
 		categoryId = categoryId,
-		mangaId = mangaId,
+		mangaIds = mangaIds,
 		deletedAt = 0L,
 	)
 
@@ -224,11 +224,11 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 	@RawQuery
 	protected abstract suspend fun findCoversImpl(query: SupportSQLiteQuery): List<Cover>
 
-	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id = :mangaId")
-	protected abstract suspend fun setDeletedAt(mangaId: Long, deletedAt: Long)
+	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id IN (:mangaIds)")
+	protected abstract suspend fun setDeletedAt(mangaIds: Collection<Long>, deletedAt: Long)
 
-	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id = :mangaId AND category_id = :categoryId")
-	protected abstract suspend fun setDeletedAt(categoryId: Long, mangaId: Long, deletedAt: Long)
+	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id IN (:mangaIds) AND category_id = :categoryId")
+	protected abstract suspend fun setDeletedAt(categoryId: Long, mangaIds: Collection<Long>, deletedAt: Long)
 
 	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE category_id = :categoryId AND deleted_at = 0")
 	protected abstract suspend fun setDeletedAtAll(categoryId: Long, deletedAt: Long)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
@@ -288,9 +288,10 @@ class FavouritesRepository @Inject constructor(
 	}
 
 	suspend fun removeFromFavourites(ids: Collection<Long>): ReversibleHandle {
+		if (ids.isEmpty()) return ReversibleHandle {}
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().delete(mangaId = id)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().delete(mangaIds = chunk)
 			}
 			db.getChaptersDao().gc()
 		}
@@ -298,9 +299,10 @@ class FavouritesRepository @Inject constructor(
 	}
 
 	suspend fun removeFromCategory(categoryId: Long, ids: Collection<Long>): ReversibleHandle {
+		if (ids.isEmpty()) return ReversibleHandle {}
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().delete(categoryId = categoryId, mangaId = id)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().delete(categoryId = categoryId, mangaIds = chunk)
 			}
 			db.getChaptersDao().gc()
 		}
@@ -321,17 +323,19 @@ class FavouritesRepository @Inject constructor(
 	}
 
 	private suspend fun recoverToFavourites(ids: Collection<Long>) {
+		if (ids.isEmpty()) return
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().recover(mangaId = id)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().recover(mangaIds = chunk)
 			}
 		}
 	}
 
 	private suspend fun recoverToCategory(categoryId: Long, ids: Collection<Long>) {
+		if (ids.isEmpty()) return
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().recover(mangaId = id, categoryId = categoryId)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().recover(categoryId = categoryId, mangaIds = chunk)
 			}
 		}
 	}


### PR DESCRIPTION
💡 **What:** 
Replaced sequential iterative single-item `UPDATE` calls with batch `UPDATE` calls using an `IN (:ids)` clause in `FavouritesDao`. Safely chunked the ID list into chunks of `900` to prevent reaching SQLite variable limits. The affected operations include deleting, removing, and recovering categories and favourites.

🎯 **Why:** 
The previous implementation performed O(N) database queries during loops (`for (id in ids) db.getFavouritesDao().delete(mangaId = id)`), which held up transactions and degraded performance for larger operations. With the new implementation, it performs `O(N/900)` queries which makes these bulk operations much faster and cleaner.

📊 **Measured Improvement:** 
This optimization transforms an operation that linearly scaled database query hits by `N` into `N/900`. This reduces overhead drastically on large operations such as select all favourites and recovering them.

---
*PR created automatically by Jules for task [4015235444843814958](https://jules.google.com/task/4015235444843814958) started by @HuzaifaKhalid1311*