### PR TITLE
🧹 Improve AdBlock CSS cosmetic rules parsing

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
@@ -52,7 +52,7 @@ class RulesList {
 				substring(2).substringBefore('^').trim().addImpl(!isWhitelist, modifiers)
 			}
 
-			startsWith("##") -> {
+			contains("##") || contains("#@#") || contains("#?#") || contains("#$#") -> {
 				// TODO css rules
 			}
 


### PR DESCRIPTION
🎯 **What:** The previous implementation only ignored CSS cosmetic rules if they started with `##`. This caused domain-specific CSS rules (e.g., `example.com##.ads`) or exceptions (`#@#`, `#?#`, `#$#`) to fall through to the `else` block and be incorrectly parsed as network path blocking rules. I have updated the check to use `contains` for all valid element hiding and snippet separators.
💡 **Why:** Implementing CSS injection via JS is complex and currently unsupported. Parsing them incorrectly as URL blocking rules pollutes the block list and might break legitimate requests. Ignoring them correctly improves maintainability and system correctness.
✅ **Verification:** Verified by writing temporary test cases and running the existing test suite via `./gradlew test -PskipLint`.
✨ **Result:** AdBlock rules with element hiding or snippets are now correctly skipped and won't pollute network blocking.

---
*PR created automatically by Jules for task [10846185138114287605](https://jules.google.com/task/10846185138114287605) started by @HuzaifaKhalid1311*