### PR TITLE
Implement memory trimming handling in BasePageHolder

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
@@ -2,6 +2,7 @@ package org.koitharu.kotatsu.reader.ui.pager
 
 import android.content.ComponentCallbacks2
 import android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.Context
 import android.content.res.Configuration
 import android.view.View
@@ -116,8 +117,13 @@ abstract class BasePageHolder<B : ViewBinding>(
 	override fun onResume() {
 		super.onResume()
 		ssiv.applyDownSampling(isForeground = true)
-		if (viewModel.state.value is PageState.Error && !viewModel.isLoading()) {
+		val state = viewModel.state.value
+		if (state is PageState.Empty) {
+			boundData?.let { bind(it) }
+		} else if (state is PageState.Error && !viewModel.isLoading()) {
 			boundData?.let { viewModel.retry(it.toMangaPage(), isFromUser = false) }
+		} else if (state is PageState.Shown && ssiv.getState() == null) {
+			reloadImage()
 		}
 	}
 
@@ -142,7 +148,12 @@ abstract class BasePageHolder<B : ViewBinding>(
 	}
 
 	override fun onTrimMemory(level: Int) {
-		// TODO
+		if (isResumed()) return
+		if (level >= TRIM_MEMORY_COMPLETE) {
+			onRecycled()
+		} else if (level >= TRIM_MEMORY_RUNNING_LOW) {
+			ssiv.recycle()
+		}
 	}
 
 	override fun onConfigurationChanged(newConfig: Configuration) = Unit


### PR DESCRIPTION
This change implements `onTrimMemory` in `BasePageHolder` to properly clear memory when Android's OS level triggers a trim.

It correctly utilizes `ssiv.recycle()` when hitting `TRIM_MEMORY_RUNNING_LOW` and entirely resets the state using `onRecycled()` when reaching `TRIM_MEMORY_COMPLETE`. 
Additionally, `onResume` is updated to correctly rebuild the view or reload the image if the memory had been trimmed, ensuring that no blank views appear for the user when returning to the application or scrolling back.

---
*PR created automatically by Jules for task [13059571519659914357](https://jules.google.com/task/13059571519659914357) started by @HuzaifaKhalid1311*