### PR TITLE
⚡ Optimize batch deletions in FavouritesRepository

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
@@ -187,9 +187,20 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 		deletedAt = System.currentTimeMillis(),
 	)
 
+	suspend fun delete(mangaIds: Collection<Long>) = setDeletedAt(
+		mangaIds = mangaIds,
+		deletedAt = System.currentTimeMillis(),
+	)
+
 	suspend fun delete(mangaId: Long, categoryId: Long) = setDeletedAt(
 		categoryId = categoryId,
 		mangaId = mangaId,
+		deletedAt = System.currentTimeMillis(),
+	)
+
+	suspend fun delete(categoryId: Long, mangaIds: Collection<Long>) = setDeletedAt(
+		categoryId = categoryId,
+		mangaIds = mangaIds,
 		deletedAt = System.currentTimeMillis(),
 	)
 
@@ -203,9 +214,20 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 		deletedAt = 0L,
 	)
 
+	suspend fun recover(mangaIds: Collection<Long>) = setDeletedAt(
+		mangaIds = mangaIds,
+		deletedAt = 0L,
+	)
+
 	suspend fun recover(categoryId: Long, mangaId: Long) = setDeletedAt(
 		categoryId = categoryId,
 		mangaId = mangaId,
+		deletedAt = 0L,
+	)
+
+	suspend fun recover(categoryId: Long, mangaIds: Collection<Long>) = setDeletedAt(
+		categoryId = categoryId,
+		mangaIds = mangaIds,
 		deletedAt = 0L,
 	)
 
@@ -227,8 +249,14 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id = :mangaId")
 	protected abstract suspend fun setDeletedAt(mangaId: Long, deletedAt: Long)
 
+	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id IN (:mangaIds)")
+	protected abstract suspend fun setDeletedAt(mangaIds: Collection<Long>, deletedAt: Long)
+
 	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id = :mangaId AND category_id = :categoryId")
 	protected abstract suspend fun setDeletedAt(categoryId: Long, mangaId: Long, deletedAt: Long)
+
+	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE manga_id IN (:mangaIds) AND category_id = :categoryId")
+	protected abstract suspend fun setDeletedAt(categoryId: Long, mangaIds: Collection<Long>, deletedAt: Long)
 
 	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE category_id = :categoryId AND deleted_at = 0")
 	protected abstract suspend fun setDeletedAtAll(categoryId: Long, deletedAt: Long)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
@@ -289,8 +289,10 @@ class FavouritesRepository @Inject constructor(
 
 	suspend fun removeFromFavourites(ids: Collection<Long>): ReversibleHandle {
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().delete(mangaId = id)
+			if (ids.isNotEmpty()) {
+				ids.chunked(900).forEach { chunk ->
+					db.getFavouritesDao().delete(mangaIds = chunk)
+				}
 			}
 			db.getChaptersDao().gc()
 		}
@@ -299,8 +301,10 @@ class FavouritesRepository @Inject constructor(
 
 	suspend fun removeFromCategory(categoryId: Long, ids: Collection<Long>): ReversibleHandle {
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().delete(categoryId = categoryId, mangaId = id)
+			if (ids.isNotEmpty()) {
+				ids.chunked(900).forEach { chunk ->
+					db.getFavouritesDao().delete(categoryId = categoryId, mangaIds = chunk)
+				}
 			}
 			db.getChaptersDao().gc()
 		}
@@ -321,17 +325,19 @@ class FavouritesRepository @Inject constructor(
 	}
 
 	private suspend fun recoverToFavourites(ids: Collection<Long>) {
+		if (ids.isEmpty()) return
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().recover(mangaId = id)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().recover(mangaIds = chunk)
 			}
 		}
 	}
 
 	private suspend fun recoverToCategory(categoryId: Long, ids: Collection<Long>) {
+		if (ids.isEmpty()) return
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().recover(mangaId = id, categoryId = categoryId)
+			ids.chunked(900).forEach { chunk ->
+				db.getFavouritesDao().recover(categoryId = categoryId, mangaIds = chunk)
 			}
 		}
 	}


### PR DESCRIPTION
💡 **What:**
The loop sequential DB deletions (and recoveries) in `FavouritesRepository` for items within categories were replaced with single batched queries using the SQLite `IN` clause in `FavouritesDao`. A `.chunked(900)` strategy is used to gracefully avoid the typical SQLite 999 max parameter limit.

🎯 **Why:**
Executing single SQL statements individually within a loop across `ids` adds significant overhead as Room and the underlying SQLite engine parse, compile, and execute identical queries multiple times. By using the `IN` clause, we allow the driver to process these as one bulk query. This drastically reduces the context switches and DB workload, especially on large deletion actions.

📊 **Measured Improvement:**
Since tests involving `Room` directly require a physical emulator or `robolectric` (which are unavailable/unmet constraints in the current environment context), local instrumentation baselines could not be generated. However, the performance benefit of batch SQL executions is a widely established optimization fact. By removing O(N) operations in `removeFromCategory`, `removeFromFavourites`, `recoverToCategory`, and `recoverToFavourites` and turning them into O(N/900), the overhead in context-switching and statement generation drops substantially, leading to consistently snappier deletions for long lists.

---
*PR created automatically by Jules for task [11888994565586951701](https://jules.google.com/task/11888994565586951701) started by @HuzaifaKhalid1311*