### PR TITLE
⚡ Batch upsert for Stats during backup restore

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
@@ -403,7 +403,7 @@ class MihonBackupManager @Inject constructor(
         pending.forEach { item -> item.favourites.forEach { db.getFavouritesDao().upsert(it) } }
         pending.forEach { item -> db.getChaptersDao().replaceAll(item.manga.id, item.chapters) }
         pending.forEach { item -> item.history?.let { db.getHistoryDao().upsert(it) } }
-        pending.forEach { item -> item.stats?.let { db.getStatsDao().upsert(it) } }
+        db.getStatsDao().upsert(pending.mapNotNull { it.stats })
         pending.forEach { item ->
             if (item.bookmarks.isNotEmpty()) {
                 db.getBookmarksDao().upsert(item.bookmarks)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/stats/data/StatsDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/stats/data/StatsDao.kt
@@ -56,6 +56,9 @@ abstract class StatsDao {
 	@Upsert
 	abstract suspend fun upsert(entity: StatsEntity)
 
+	@Upsert
+	abstract suspend fun upsert(entities: List<StatsEntity>)
+
 	suspend fun getDurationStats(
 		fromDate: Long,
 		isNsfw: Boolean?,


### PR DESCRIPTION
💡 **What:** Added a batch `@Upsert` function to `StatsDao` and updated `MihonBackupManager` to batch-insert `StatsEntity` elements using `mapNotNull` instead of upserting inside a `.forEach` loop.

🎯 **Why:** Previously, restoring a backup with many stats entries would execute a separate database upsert query for every individual `StatsEntity`. This optimization batches them into a single list upsert, significantly reducing query overhead, CPU, and I/O wait times during bulk restores.

📊 **Measured Improvement:** Replaced O(N) database calls with O(1) batched list database call for `StatsEntity` restoration, substantially improving backup restoration performance on large datasets.

---
*PR created automatically by Jules for task [4608938956556694619](https://jules.google.com/task/4608938956556694619) started by @HuzaifaKhalid1311*