### PR TITLE
🧹 Fix hardcoded exception message in ProxyProvider

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
@@ -13,6 +13,9 @@ import okhttp3.Response
 import okhttp3.Route
 import okio.IOException
 import org.koitharu.kotatsu.core.exceptions.ProxyConfigException
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.network.CommonHeaders
 import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
@@ -30,6 +33,7 @@ import java.net.Authenticator as JavaAuthenticator
 
 @Singleton
 class ProxyProvider @Inject constructor(
+	@ApplicationContext private val context: Context,
 	private val settings: AppSettings,
 ) {
 
@@ -56,7 +60,7 @@ class ProxyProvider @Inject constructor(
 		val isProxyEnabled = isProxyEnabled()
 		if (!WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
 			if (isProxyEnabled) {
-				throw IllegalArgumentException("Proxy for WebView is not supported") // TODO localize
+				throw IllegalArgumentException(context.getString(R.string.proxy_webview_not_supported))
 			}
 		} else {
 			val controller = ProxyController.getInstance()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,6 +847,7 @@
     <string name="plugin_incompatible_with_cause">Plugin error: %s\n Make sure you are using the latest version of the plugin and DropSauce</string>
     <string name="connection_ok">Connection is OK</string>
     <string name="invalid_proxy_configuration">Invalid proxy configuration</string>
+    <string name="proxy_webview_not_supported">Proxy for WebView is not supported</string>
     <string name="show_quick_filters">Show quick filters</string>
     <string name="show_quick_filters_summary">Provides the ability to filter manga lists by certain parameters</string>
     <string name="sfw">SFW</string>


### PR DESCRIPTION
🎯 **What:** Localized hardcoded exception message in `ProxyProvider`.
💡 **Why:** Replaces hardcoded string with localized string resource.
✅ **Verification:** Ran test suite to verify no regressions were introduced. Note: pre-existing failure in ReadingProgressTest.kt remains.
✨ **Result:** Better maintainability through localized strings.

---
*PR created automatically by Jules for task [5914094863766802202](https://jules.google.com/task/5914094863766802202) started by @HuzaifaKhalid1311*