### PR TITLE
⚡ Optimize `FavouritesRepository.removeCategories` performance

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouriteCategoriesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouriteCategoriesDao.kt
@@ -35,6 +35,8 @@ abstract class FavouriteCategoriesDao {
 
 	suspend fun delete(id: Long) = setDeletedAt(id, System.currentTimeMillis())
 
+	suspend fun delete(ids: Collection<Long>) = setDeletedAt(ids, System.currentTimeMillis())
+
 	@Query("UPDATE favourite_categories SET title = :title, `order` = :order, `track` = :tracker, download_new_chapters = :downloadNewChapters, `show_in_lib` = :onShelf WHERE category_id = :id")
 	abstract suspend fun update(
 		id: Long,
@@ -85,4 +87,7 @@ abstract class FavouriteCategoriesDao {
 
 	@Query("UPDATE favourite_categories SET deleted_at = :deletedAt WHERE category_id = :id")
 	protected abstract suspend fun setDeletedAt(id: Long, deletedAt: Long)
+
+	@Query("UPDATE favourite_categories SET deleted_at = :deletedAt WHERE category_id IN (:ids)")
+	protected abstract suspend fun setDeletedAt(ids: Collection<Long>, deletedAt: Long)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouritesDao.kt
@@ -198,6 +198,11 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 		deletedAt = System.currentTimeMillis(),
 	)
 
+	suspend fun deleteAll(categoryIds: Collection<Long>) = setDeletedAtAll(
+		categoryIds = categoryIds,
+		deletedAt = System.currentTimeMillis(),
+	)
+
 	suspend fun recover(mangaId: Long) = setDeletedAt(
 		mangaId = mangaId,
 		deletedAt = 0L,
@@ -232,6 +237,9 @@ abstract class FavouritesDao : MangaQueryBuilder.ConditionCallback {
 
 	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE category_id = :categoryId AND deleted_at = 0")
 	protected abstract suspend fun setDeletedAtAll(categoryId: Long, deletedAt: Long)
+
+	@Query("UPDATE favourites SET deleted_at = :deletedAt WHERE category_id IN (:categoryIds) AND deleted_at = 0")
+	protected abstract suspend fun setDeletedAtAll(categoryIds: Collection<Long>, deletedAt: Long)
 
 	private fun getOrderBy(sortOrder: ListSortOrder) = when (sortOrder) {
 		ListSortOrder.RATING -> "manga.rating DESC"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/domain/FavouritesRepository.kt
@@ -246,11 +246,10 @@ class FavouritesRepository @Inject constructor(
 	}
 
 	suspend fun removeCategories(ids: Collection<Long>) {
+		if (ids.isEmpty()) return
 		db.withTransaction {
-			for (id in ids) {
-				db.getFavouritesDao().deleteAll(id)
-				db.getFavouriteCategoriesDao().delete(id)
-			}
+			db.getFavouritesDao().deleteAll(ids)
+			db.getFavouriteCategoriesDao().delete(ids)
 			db.getChaptersDao().gc()
 		}
 	}


### PR DESCRIPTION
💡 **What:** Replaced sequential individual category deletions inside a `for` loop with a single bulk deletion query using an `IN` clause.
🎯 **Why:** To improve performance and reduce database round-trips. Executing multiple sequential deletes is slower than a single batch delete, especially since the queries were already wrapped in a database transaction.
📊 **Measured Improvement:** The number of executed queries changes from `2 * N` (where N is the number of deleted IDs) to just 2 static queries. No additional benchmarking was possible in the environment.

---
*PR created automatically by Jules for task [4100960324433223752](https://jules.google.com/task/4100960324433223752) started by @HuzaifaKhalid1311*