### PR TITLE
Localize WebView proxy exception

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/WebViewProxyNotSupportedException.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/WebViewProxyNotSupportedException.kt
@@ -1,0 +1,3 @@
+package org.koitharu.kotatsu.core.exceptions
+
+class WebViewProxyNotSupportedException : RuntimeException("Proxy for WebView is not supported")

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
@@ -56,7 +56,7 @@ class ProxyProvider @Inject constructor(
 		val isProxyEnabled = isProxyEnabled()
 		if (!WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
 			if (isProxyEnabled) {
-				throw IllegalArgumentException("Proxy for WebView is not supported") // TODO localize
+				throw org.koitharu.kotatsu.core.exceptions.WebViewProxyNotSupportedException()
 			}
 		} else {
 			val controller = ProxyController.getInstance()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Throwable.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Throwable.kt
@@ -28,6 +28,7 @@ import org.koitharu.kotatsu.core.exceptions.InteractiveActionRequiredException
 import org.koitharu.kotatsu.core.exceptions.NoDataReceivedException
 import org.koitharu.kotatsu.core.exceptions.NonFileUriException
 import org.koitharu.kotatsu.core.exceptions.ProxyConfigException
+import org.koitharu.kotatsu.core.exceptions.WebViewProxyNotSupportedException
 import org.koitharu.kotatsu.core.exceptions.SyncApiException
 import org.koitharu.kotatsu.core.exceptions.UnsupportedFileException
 import org.koitharu.kotatsu.core.exceptions.UnsupportedSourceException
@@ -106,6 +107,7 @@ private fun Throwable.getDisplayMessageOrNull(resources: Resources): String? = w
     is EmptyHistoryException -> resources.getString(R.string.history_is_empty)
     is EmptyMangaException -> reason?.let { resources.getString(it.msgResId) } ?: cause?.getDisplayMessage(resources)
     is ProxyConfigException -> resources.getString(R.string.invalid_proxy_configuration)
+    is WebViewProxyNotSupportedException -> resources.getString(R.string.webview_proxy_not_supported)
     is SyncApiException,
     is ContentUnavailableException -> message
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,6 +847,7 @@
     <string name="plugin_incompatible_with_cause">Plugin error: %s\n Make sure you are using the latest version of the plugin and DropSauce</string>
     <string name="connection_ok">Connection is OK</string>
     <string name="invalid_proxy_configuration">Invalid proxy configuration</string>
+    <string name="webview_proxy_not_supported">Proxy for WebView is not supported</string>
     <string name="show_quick_filters">Show quick filters</string>
     <string name="show_quick_filters_summary">Provides the ability to filter manga lists by certain parameters</string>
     <string name="sfw">SFW</string>


### PR DESCRIPTION
Replace hardcoded string with string resource reference by creating a custom exception `WebViewProxyNotSupportedException` and mapping it to the localized string in `Throwable.getDisplayMessageOrNull`.

---
*PR created automatically by Jules for task [10958946651633857386](https://jules.google.com/task/10958946651633857386) started by @HuzaifaKhalid1311*