### PR TITLE
feat: implement missing adblock rule modifiers

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
@@ -40,6 +40,12 @@ sealed interface Rule {
 			if (!baseRule.invoke(url, baseUrl)) {
 				return false
 			}
+			script?.let {
+				val isScript = url.encodedPath.endsWith(".js")
+				if (isScript != it) {
+					return false
+				}
+			}
 			if (baseUrl == null) {
 				return true
 			}
@@ -50,7 +56,16 @@ sealed interface Rule {
 					return false
 				}
 			}
-			// TODO check other modifiers
+			domainsNot?.let { nots ->
+				if (nots.any { baseUrl.host == it || baseUrl.host.endsWith(".$it") }) {
+					return false
+				}
+			}
+			domains?.let { doms ->
+				if (doms.none { baseUrl.host == it || baseUrl.host.endsWith(".$it") }) {
+					return false
+				}
+			}
 			return true
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
@@ -73,19 +73,27 @@ class RulesList {
 		}
 		var script: Boolean? = null
 		var thirdParty: Boolean? = null
+		var domains: Set<String>? = null
+		var domainsNot: Set<String>? = null
 		options.split(',').forEach {
 			val isNot = it.startsWith('~')
-			when (it.removePrefix("~")) {
-				"script" -> script = !isNot
-				"third-party" -> thirdParty = !isNot
+			val option = it.removePrefix("~")
+			when {
+				option == "script" -> script = !isNot
+				option == "third-party" -> thirdParty = !isNot
+				option.startsWith("domain=") -> {
+					val domainList = option.substringAfter("domain=").split('|')
+					domains = domainList.filter { d -> !d.startsWith('~') }.toSet().takeIf { s -> s.isNotEmpty() }
+					domainsNot = domainList.filter { d -> d.startsWith('~') }.map { d -> d.removePrefix("~") }.toSet().takeIf { s -> s.isNotEmpty() }
+				}
 			}
 		}
 		return Rule.WithModifiers(
 			baseRule = this,
 			script = script,
 			thirdParty = thirdParty,
-			domains = null, //TODO
-			domainsNot = null, //TODO
+			domains = domains,
+			domainsNot = domainsNot,
 		)
 	}
 }


### PR DESCRIPTION
Implemented parsing and evaluation logic for adblock rule modifiers including `domain`, negated domain `~domain`, and `script` filters in `RulesList.kt` and `Rule.kt`.

---
*PR created automatically by Jules for task [16742691358677222221](https://jules.google.com/task/16742691358677222221) started by @HuzaifaKhalid1311*