### PR TITLE
🧪 Add missing test file for Hash utilities

### DIFF
--- a/app/src/test/kotlin/eu/kanade/tachiyomi/util/lang/HashTest.kt
+++ b/app/src/test/kotlin/eu/kanade/tachiyomi/util/lang/HashTest.kt
@@ -1,0 +1,71 @@
+package eu.kanade.tachiyomi.util.lang
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HashTest {
+
+	@Test
+	fun `sha256 of empty string`() {
+		assertEquals(
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			Hash.sha256("")
+		)
+	}
+
+	@Test
+	fun `sha256 of basic string`() {
+		assertEquals(
+			"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			Hash.sha256("test")
+		)
+	}
+
+	@Test
+	fun `sha256 of string with spaces and special characters`() {
+		assertEquals(
+			"230cd5d039fa491794b022261091f53de649487ab2a2dabec7dee37a67beda0a",
+			Hash.sha256("Hello, World! 123")
+		)
+	}
+
+	@Test
+	fun `sha256 of byte array`() {
+		assertEquals(
+			"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			Hash.sha256("test".toByteArray())
+		)
+	}
+
+	@Test
+	fun `md5 of empty string`() {
+		assertEquals(
+			"d41d8cd98f00b204e9800998ecf8427e",
+			Hash.md5("")
+		)
+	}
+
+	@Test
+	fun `md5 of basic string`() {
+		assertEquals(
+			"098f6bcd4621d373cade4e832627b4f6",
+			Hash.md5("test")
+		)
+	}
+
+	@Test
+	fun `md5 of string with spaces and special characters`() {
+		assertEquals(
+			"8a732eef6124eb6b5aa8c0af2318fdbb",
+			Hash.md5("Hello, World! 123")
+		)
+	}
+
+	@Test
+	fun `md5 of byte array`() {
+		assertEquals(
+			"098f6bcd4621d373cade4e832627b4f6",
+			Hash.md5("test".toByteArray())
+		)
+	}
+}


### PR DESCRIPTION
🎯 **What:** 
Added a missing unit test file `HashTest.kt` for the `Hash` utility functions `sha256` and `md5`.

📊 **Coverage:**
The tests cover both String and ByteArray variations for both hashing algorithms. It tests empty strings, basic standard strings, and complex strings with spaces and special characters.

✨ **Result:**
Test coverage and codebase reliability has been improved by explicitly verifying that the simple pure string mapping functions for `sha256` and `md5` produce the correct and deterministic output values.

---
*PR created automatically by Jules for task [5128652987990926390](https://jules.google.com/task/5128652987990926390) started by @HuzaifaKhalid1311*