### PR TITLE
🧹 Use OkHttp initialization instead of PlatformRegistry

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -13,7 +13,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.platform.PlatformRegistry
+import okhttp3.OkHttp
 import org.acra.ACRA
 import org.acra.config.dialog
 import org.acra.data.StringFormat
@@ -71,7 +71,7 @@ open class BaseApp : Application(), Configuration.Provider {
 
 	override fun onCreate() {
 		super.onCreate()
-		PlatformRegistry.applicationContext = this // TODO replace with OkHttp.initialize
+		OkHttp.initialize(this)
 		if (ACRA.isACRASenderServiceProcess()) {
 			return
 		}


### PR DESCRIPTION
🎯 **What:** Replaced the direct assignment of `PlatformRegistry.applicationContext` with `OkHttp.initialize(this)` in `BaseApp.kt` and removed the unused internal import.
💡 **Why:** `PlatformRegistry` is an internal `okhttp3.internal.platform` class that is not meant for direct application usage. OkHttp provides an `initialize` method specifically designed for this purpose, improving encapsulation and reducing reliance on internal library structures.
✅ **Verification:** Verified through Code Review and verified test stability by running `./gradlew clean test` (note: some unrelated test failures exist in `ReadingProgressTest`, but changes in `BaseApp.kt` are sound).
✨ **Result:** A cleaner initialization sequence that correctly uses the OkHttp public API rather than mutating its internals.

---
*PR created automatically by Jules for task [17154077346924902496](https://jules.google.com/task/17154077346924902496) started by @HuzaifaKhalid1311*