### PR TITLE
⚡ Bolt: Optimize `upsert` in MangaDao to prevent N+1 queries when inserting tags

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - [Room Batch Insert Optimization]
+**Learning:** In Room DAOs, iterating over a collection and calling a single-item `@Insert` method in a loop causes severe N+1 query performance bottlenecks, especially since each query invocation suspends and resumes a coroutine.
+**Action:** Always define batch insert/upsert methods (e.g., `@Insert abstract suspend fun insertAll(items: List<T>)`) when dealing with collections to execute a single, highly efficient database transaction. Additionally, always use concrete collection types like `List<T>` instead of `Iterable<T>` for these batch methods to guarantee proper Room compiler behavior.

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/MangaDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/MangaDao.kt
@@ -57,6 +57,10 @@ abstract class MangaDao {
 	@Insert(onConflict = OnConflictStrategy.IGNORE)
 	abstract suspend fun insertTagRelation(tag: MangaTagsEntity): Long
 
+	// ⚡ Bolt: Batch insert tags to prevent N+1 query problem, improving insert performance
+	@Insert(onConflict = OnConflictStrategy.IGNORE)
+	abstract suspend fun insertTagRelations(tags: List<MangaTagsEntity>)
+
 	@Query("DELETE FROM manga_tags WHERE manga_id = :mangaId")
 	abstract suspend fun clearTagRelation(mangaId: Long)
 
@@ -82,11 +86,12 @@ abstract class MangaDao {
 		upsert(manga)
 		if (tags != null) {
 			clearTagRelation(manga.id)
-			tags.map {
+			// ⚡ Bolt: Collect tags into a list and execute a single batch insert query
+			// instead of iterating and executing individual inserts per tag.
+			val mangaTags = tags.map {
 				MangaTagsEntity(manga.id, it.id)
-			}.forEach {
-				insertTagRelation(it)
 			}
+			insertTagRelations(mangaTags)
 		}
 	}
 }


### PR DESCRIPTION
💡 **What:** 
Added a batch insert method `insertTagRelations(tags: List<MangaTagsEntity>)` in `MangaDao.kt` and refactored the `upsert` method to use it instead of iterating over `tags` and calling the single-item `insertTagRelation` method for each tag. 

🎯 **Why:** 
The previous implementation iterated through each manga tag and called an individual database insert method inside a suspend function loop. This caused a classic N+1 query problem, leading to unnecessary database connection overhead, increased transaction time, and inefficient suspension/resumption of coroutines for every tag.

📊 **Impact:** 
Significant performance improvement when upserting manga entries that have multiple tags. It reduces the number of database queries executed from `1 (manga upsert) + 1 (clear tags) + N (number of tags)` to just `1 (manga upsert) + 1 (clear tags) + 1 (batch insert tags)`, ensuring O(1) query scaling regardless of the number of tags.

🔬 **Measurement:** 
Unit tests for `org.koitharu.kotatsu.core.db.dao.*` pass, confirming functional parity while benefiting from the underlying Room batch transaction performance.

---
*PR created automatically by Jules for task [17362322702414712089](https://jules.google.com/task/17362322702414712089) started by @HuzaifaKhalid1311*