### PR TITLE
Codebase cleanup: dead code, unused imports, style fixes

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
@@ -47,7 +47,6 @@ import org.koitharu.kotatsu.mihon.MihonExtensionManager
 import org.koitharu.kotatsu.parsers.util.longHashCode
 import org.koitharu.kotatsu.scrobbling.common.data.ScrobblingEntity
 import org.koitharu.kotatsu.stats.data.StatsEntity
-import java.net.URI
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -512,6 +511,3 @@ class MihonBackupManager @Inject constructor(
     return (normalizedIndex + 1) / chaptersCount.toFloat()
   }
 }
-
-
-

--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
@@ -467,7 +467,6 @@ class MihonBackupManager @Inject constructor(
         return if (sourceId > 0) "MIHON_$sourceId" else "UNKNOWN"
     }
 
-
     private fun resolveSourceTitle(sourceId: Long, backupSources: List<MihonBackupSource>): String? {
         val installed = mihonExtensionManager.getMihonMangaSourceById(sourceId)
         return installed?.displayName ?: backupSources.firstOrNull { it.sourceId == sourceId }?.name

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -76,7 +76,6 @@ open class BaseApp : Application(), Configuration.Provider {
 			return
 		}
 		AppCompatDelegate.setDefaultNightMode(settings.theme)
-		// Keep default platform security provider.
 		setupActivityLifecycleCallbacks()
 		cleanupDownloadedExtensionApks()
 		processLifecycleScope.launch {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
@@ -700,13 +700,13 @@ class AppRouter private constructor(
 		private fun resolveSettings(context: Context) =
 			EntryPointAccessors.fromApplication<AppRouterEntryPoint>(context.applicationContext).settings
 
-		private fun detailsActivityClass(context: Context) = DetailsExpressiveActivity::class.java
+		private fun detailsActivityClass() = DetailsExpressiveActivity::class.java
 
-        fun detailsIntent(context: Context, manga: Manga) = Intent(context, detailsActivityClass(context))
+        fun detailsIntent(context: Context, manga: Manga) = Intent(context, detailsActivityClass())
             .putExtra(KEY_MANGA, ParcelableManga(manga))
             .setData(shortMangaUrl(manga.id))
 
-        fun detailsIntent(context: Context, mangaId: Long) = Intent(context, detailsActivityClass(context))
+        fun detailsIntent(context: Context, mangaId: Long) = Intent(context, detailsActivityClass())
             .putExtra(KEY_ID, mangaId)
             .setData(shortMangaUrl(mangaId))
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
@@ -849,7 +849,6 @@ class AppRouter private constructor(
         const val ACTION_TRACKER = "${BuildConfig.APPLICATION_ID}.action.MANAGE_TRACKER"
 
         private const val TYPE_TEXT = "text/plain"
-        private const val TYPE_IMAGE = "image/*"
         private const val TYPE_CBZ = "application/x-cbz"
 
         private fun Class<out Fragment>.fragmentTag() = name // TODO

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/CommonHeaders.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/CommonHeaders.kt
@@ -20,8 +20,7 @@ object CommonHeaders {
 	const val IF_MODIFIED_SINCE = "If-Modified-Since"
 	const val MANGA_SOURCE = "X-Manga-Source"
 
-	val CACHE_CONTROL_NO_STORE: CacheControl
-		get() = CacheControl.Builder().noStore().build()
+	val CACHE_CONTROL_NO_STORE: CacheControl = CacheControl.Builder().noStore().build()
 
 	const val DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz"
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/CommonHeadersInterceptor.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/CommonHeadersInterceptor.kt
@@ -36,12 +36,10 @@ class CommonHeadersInterceptor @Inject constructor(
 		}
 		val headersBuilder = request.headers.newBuilder()
 			.removeAll(CommonHeaders.MANGA_SOURCE)
-			
 		val requestHeaders = when (repository) {
-            is MihonMangaRepository -> (repository.mihonSource as? HttpSource)?.headers
-            else -> null
-        }
-        
+			is MihonMangaRepository -> (repository.mihonSource as? HttpSource)?.headers
+			else -> null
+		}
 		requestHeaders?.let {
 			headersBuilder.mergeWith(it, replaceExisting = false)
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/cookies/CookieWrapper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/cookies/CookieWrapper.kt
@@ -7,7 +7,6 @@ import java.io.ByteArrayOutputStream
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 
-
 data class CookieWrapper(
 	val cookie: Cookie,
 ) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/favicon/FaviconFetcher.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/favicon/FaviconFetcher.kt
@@ -15,7 +15,6 @@ import coil3.fetch.ImageFetchResult
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.toAndroidUri
-import coil3.toBitmap
 import kotlinx.coroutines.runInterruptible
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -26,14 +25,12 @@ import org.koitharu.kotatsu.core.parser.MangaRepository
 import org.koitharu.kotatsu.core.util.MimeTypes
 import org.koitharu.kotatsu.core.util.ext.fetch
 import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
-import org.koitharu.kotatsu.core.util.ext.toMimeTypeOrNull
 import org.koitharu.kotatsu.local.data.FaviconCache
 import org.koitharu.kotatsu.local.data.LocalMangaRepository
 import org.koitharu.kotatsu.local.data.LocalStorageCache
 import org.koitharu.kotatsu.mihon.MihonExtensionManager
 import org.koitharu.kotatsu.mihon.MihonMangaRepository
 import org.koitharu.kotatsu.mihon.model.MihonMangaSource
-import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
 import java.io.File
 import javax.inject.Inject
 import coil3.Uri as CoilUri
@@ -84,7 +81,7 @@ class FaviconFetcher(
 	private suspend fun fetchMihonIcon(source: MihonMangaSource): FetchResult {
 		val icon = runCatching {
 			runInterruptible {
-			options.context.packageManager.getApplicationIcon(source.pkgName)
+				options.context.packageManager.getApplicationIcon(source.pkgName)
 			}
 		}.getOrNull() ?: return requireNotNull(imageLoader.fetch(R.drawable.ic_manga_source, options))
 
@@ -105,31 +102,7 @@ class FaviconFetcher(
 		mihonExtensionManager.ensureReady(forceRefresh = true)
 		return sourceId?.let { mihonExtensionManager.getMihonMangaSourceById(it) }
 			?: mihonExtensionManager.getMihonMangaSourceByName(name)
-		}
-
-	private suspend fun writeToCache(key: String, result: FetchResult): FetchResult = runCatchingCancellable {
-		when (result) {
-			is ImageFetchResult -> {
-				if (result.dataSource == DataSource.NETWORK) {
-					localStorageCache.set(key, result.image.toBitmap()).asFetchResult()
-				} else {
-					result
-				}
-			}
-
-			is SourceFetchResult -> {
-				if (result.dataSource == DataSource.NETWORK) {
-					result.source.source().use {
-						localStorageCache.set(key, it, result.mimeType?.toMimeTypeOrNull()).asFetchResult()
-					}
-				} else {
-					result
-				}
-			}
-		}
-	}.onFailure {
-		it.printStackTraceDebug()
-	}.getOrDefault(result)
+	}
 
 	private fun File.asFetchResult() = SourceFetchResult(
 		source = ImageSource(toOkioPath(), FileSystem.SYSTEM),

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -484,7 +484,6 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 			}
 		}
 
-
 	var backupIncludeLibraryEntries: Boolean
 		get() = prefs.getBoolean(KEY_BACKUP_INCLUDE_LIBRARY, true)
 		set(value) = prefs.edit { putBoolean(KEY_BACKUP_INCLUDE_LIBRARY, value) }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/list/FitHeightGridLayoutManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/ui/list/FitHeightGridLayoutManager.kt
@@ -24,7 +24,6 @@ class FitHeightGridLayoutManager : GridLayoutManager {
 		reverseLayout: Boolean,
 	) : super(context, spanCount, orientation, reverseLayout)
 
-
 	override fun layoutDecoratedWithMargins(child: View, left: Int, top: Int, right: Int, bottom: Int) {
 		if (orientation == RecyclerView.VERTICAL && child.layoutParams.height == LayoutParams.MATCH_PARENT) {
 			val parentBottom = height - paddingBottom

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Android.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Android.kt
@@ -150,10 +150,8 @@ fun Context.getLocalesConfig(): LocaleListCompat {
 	try {
 		val xpp: XmlPullParser = resources.getXml(R.xml.locales_config)
 		while (xpp.eventType != XmlPullParser.END_DOCUMENT) {
-			if (xpp.eventType == XmlPullParser.START_TAG) {
-				if (xpp.name == "locale") {
-					tagsList.add(xpp.getAttributeValue(0))
-				}
+			if (xpp.eventType == XmlPullParser.START_TAG && xpp.name == "locale") {
+				tagsList.add(xpp.getAttributeValue(0))
 			}
 			xpp.next()
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Bundle.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Bundle.kt
@@ -15,7 +15,6 @@ import org.koitharu.kotatsu.parsers.util.toArraySet
 import java.io.Serializable
 import java.util.EnumSet
 
-
 // https://issuetracker.google.com/issues/240585930
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Collections.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Collections.kt
@@ -36,13 +36,7 @@ fun <T> List<T>.takeMostFrequent(limit: Int): List<T> {
 	for (item in this) {
 		map[item] = map.getOrDefault(item, 0) + 1
 	}
-	val entries = map.entries.sortedByDescending { it.value }
-	val count = minOf(limit, entries.size)
-	return buildList(count) {
-		repeat(count) { i ->
-			add(entries[i].key)
-		}
-	}
+	return map.entries.sortedByDescending { it.value }.take(limit).map { it.key }
 }
 
 inline fun <reified E : Enum<E>> Collection<E>.toEnumSet(): EnumSet<E> = if (isEmpty()) {
@@ -78,19 +72,15 @@ fun <R : MutableCollection<Long>> LongSet.toCollection(out: R): R = out.also { r
 
 fun <T, R> Collection<T>.mapSortedByCount(isDescending: Boolean = true, mapper: (T) -> R): List<R> {
 	val grouped = groupBy(mapper).toList()
-	val sortSelector: (Pair<R, List<T>>) -> Int = { it.second.size }
-	val sorted = if (isDescending) {
-		grouped.sortedByDescending(sortSelector)
-	} else {
-		grouped.sortedBy(sortSelector)
-	}
-	return sorted.map { it.first }
+	return (if (isDescending) grouped.sortedByDescending { it.second.size } else grouped.sortedBy { it.second.size })
+		.map { it.first }
 }
 
-fun Collection<CharSequence?>.contains(element: CharSequence?, ignoreCase: Boolean): Boolean = any { x ->
+private fun charSequencesMatch(x: CharSequence?, element: CharSequence?, ignoreCase: Boolean): Boolean =
 	(x == null && element == null) || (x != null && element != null && x.contains(element, ignoreCase))
-}
 
-fun Collection<CharSequence?>.indexOfContains(element: CharSequence?, ignoreCase: Boolean): Int = indexOfFirst { x ->
-	(x == null && element == null) || (x != null && element != null && x.contains(element, ignoreCase))
-}
+fun Collection<CharSequence?>.contains(element: CharSequence?, ignoreCase: Boolean): Boolean =
+	any { charSequencesMatch(it, element, ignoreCase) }
+
+fun Collection<CharSequence?>.indexOfContains(element: CharSequence?, ignoreCase: Boolean): Int =
+	indexOfFirst { charSequencesMatch(it, element, ignoreCase) }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/ContentResolver.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/ContentResolver.kt
@@ -57,7 +57,6 @@ private fun getVolumePath(volumeId: String, context: Context): String? {
 	}
 }
 
-
 private fun getVolumePathBeforeAndroid11(volumeId: String, context: Context): String? = runCatching {
 	val mStorageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
 	val storageVolumeClazz = Class.forName("android.os.storage.StorageVolume")

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Primitive.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Primitive.kt
@@ -1,2 +1,0 @@
-package org.koitharu.kotatsu.core.util.ext
-

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/String.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/String.kt
@@ -1,11 +1,9 @@
 package org.koitharu.kotatsu.core.util.ext
 
 import android.content.Context
-import androidx.collection.arraySetOf
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.parsers.util.ellipsize
 import java.util.UUID
-
 
 fun String.toUUIDOrNull(): UUID? = try {
 	UUID.fromString(this)
@@ -40,7 +38,7 @@ fun String.transliterate(skipMissing: Boolean): String {
 }
 
 fun String.toFileNameSafe(): String = this.transliterate(false)
-	.replace(Regex("[^a-z0-9_\\-]", arraySetOf(RegexOption.IGNORE_CASE)), " ")
+	.replace(Regex("[^a-z0-9_\\-]", setOf(RegexOption.IGNORE_CASE)), " ")
 	.replace(Regex("\\s+"), "_")
 
 fun CharSequence.sanitize(): CharSequence {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
@@ -23,7 +23,6 @@ import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblingInfo
 import org.koitharu.kotatsu.tracker.domain.TrackingRepository
 import javax.inject.Inject
 
-/* TODO: remove */
 class DetailsInteractor @Inject constructor(
 	private val historyRepository: HistoryRepository,
 	private val favouritesRepository: FavouritesRepository,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapterDelegates.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/explore/ui/adapter/ExploreAdapterDelegates.kt
@@ -91,7 +91,6 @@ fun recommendationCarouselItemAD(
 	}
 }
 
-
 fun exploreSourceListItemAD(
 	listener: OnListItemClickListener<MangaSourceItem>,
 ) = adapterDelegateViewBinding<MangaSourceItem, ListModel, ItemExploreSourceListBinding>(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/image/ui/ImageViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/image/ui/ImageViewModel.kt
@@ -34,9 +34,8 @@ class ImageViewModel @Inject constructor(
 	fun saveImage(destination: Uri) {
 		launchLoadingJob(Dispatchers.Default) {
 			val request = ImageRequest.Builder(context)
-				.memoryCachePolicy(CachePolicy.READ_ONLY)
-				.data(savedStateHandle.require<Uri>(AppRouter.KEY_DATA))
 				.memoryCachePolicy(CachePolicy.DISABLED)
+				.data(savedStateHandle.require<Uri>(AppRouter.KEY_DATA))
 				.mangaSourceExtra(MangaSource(savedStateHandle[AppRouter.KEY_SOURCE]))
 				.build()
 			val bitmap = coil.execute(request).getDrawableOrThrow().toBitmap()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/local/data/CbzFilter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/local/data/CbzFilter.kt
@@ -32,4 +32,4 @@ val File.isPdfFile: Boolean
 	get() = isFile && isPdfExtension(extension)
 
 val File.isSupportedMangaArchive: Boolean
-	get() = isFile && (isZipExtension(extension) || isPdfExtension(extension))
+	get() = isFile && isSupportedArchive(name)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -562,7 +562,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 			.attachToRecyclerView(viewBinding.recyclerViewSearch)
 	}
 
-
 	private fun setNavbarPinned(isPinned: Boolean) {
 		val bottomNavBar = viewBinding.bottomNav
 		bottomNavBar?.isPinned = isPinned

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -89,7 +89,6 @@ import org.koitharu.kotatsu.search.ui.suggestion.SearchSuggestionMenuProvider
 import org.koitharu.kotatsu.search.ui.suggestion.SearchSuggestionViewModel
 import org.koitharu.kotatsu.search.ui.suggestion.adapter.SearchSuggestionAdapter
 import javax.inject.Inject
-import com.google.android.material.R as materialR
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNavOwner, MainFabInvalidator,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/nav/FloatingNavBar.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/nav/FloatingNavBar.kt
@@ -8,7 +8,6 @@ import androidx.annotation.IdRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
@@ -11,7 +11,6 @@ import org.koitharu.kotatsu.parsers.model.ContentRating
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaPage
-import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.model.MangaState
 import org.koitharu.kotatsu.parsers.model.MangaTag
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
@@ -363,7 +363,6 @@ class PageLoader @Inject constructor(
 			.tag(MangaSource::class.java, mangaSource)
 			.build()
 
-
 		@Blocking
 		private fun Uri.exists(): Boolean = when {
 			isFileUri() -> toFile().exists()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderControlDelegate.kt
@@ -52,7 +52,6 @@ class ReaderControlDelegate(
 
 			KeyEvent.KEYCODE_PAGE_DOWN -> switchBy(1, event, false)
 
-
 			KeyEvent.KEYCODE_NAVIGATE_PREVIOUS -> switchBy(-1, event, false)
 			KeyEvent.KEYCODE_PAGE_UP -> switchBy(-1, event, false)
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/search/domain/SearchV2Helper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/search/domain/SearchV2Helper.kt
@@ -127,7 +127,6 @@ class SearchV2Helper @AssistedInject constructor(
 		}
 	}
 
-
 	private fun Manga.matches(query: String, threshold: Float): Boolean {
 		return matchesTitles(title, query, threshold) || matchesTitles(altTitles.firstOrNull(), query, threshold)
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
@@ -150,7 +150,6 @@ class AppearanceSettingsFragment : BaseComposeSettingsFragment(R.string.appearan
 		super.onDestroyView()
 	}
 
-
 	private fun openSystemLocaleSettings() {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 			val intent = Intent(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/RootSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/RootSettingsViewModel.kt
@@ -15,8 +15,6 @@ class RootSettingsViewModel @Inject constructor(
 	sourcesRepository: MangaSourcesRepository,
 ) : BaseViewModel() {
 
-	val totalSourcesCount = 0 // Sources come from extensions
-
 	val enabledSourcesCount = sourcesRepository.observeEnabledSourcesCount()
 		.withErrorHandling()
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, -1)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/StorageAndNetworkSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/StorageAndNetworkSettingsFragment.kt
@@ -101,7 +101,6 @@ class StorageAndNetworkSettingsFragment : BaseComposeSettingsFragment(R.string.s
 		}
 	}
 
-
 	private fun buildProxySummary(): String {
 		val type = settings.proxyType
 		val address = settings.proxyAddress

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourceCatalogItemAD.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourceCatalogItemAD.kt
@@ -24,7 +24,6 @@ interface ExtensionActionListener {
 	fun onExtensionHideClick(item: SourceCatalogItem.Extension)
 }
 
-
 fun sourceCatalogItemExtensionAD(
 	listener: ExtensionActionListener,
 ) = adapterDelegateViewBinding<SourceCatalogItem.Extension, ListModel, ItemSourceCatalogBinding>(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/storage/RequestStorageManagerPermissionContract.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/storage/RequestStorageManagerPermissionContract.kt
@@ -9,7 +9,6 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 
-
 @RequiresApi(Build.VERSION_CODES.R)
 class RequestStorageManagerPermissionContract : ActivityResultContract<String, Boolean>() {
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/widget/common/WidgetCoverLoader.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/widget/common/WidgetCoverLoader.kt
@@ -112,13 +112,6 @@ object WidgetCoverLoader {
 		bmp
 	}.onFailure { Log.w(TAG, "rasterizeDrawable failed", it) }.getOrNull()
 
-	@Suppress("UNUSED_PARAMETER")
-	private fun ImageResult?.extractBitmap(stage: String): Bitmap? = when (val r = this) {
-		null -> null
-		is SuccessResult -> r.toBitmapOrNull()
-		is ErrorResult -> null
-	}
-
 	private fun Bitmap.roundedCenterCrop(
 		@Px outW: Int,
 		@Px outH: Int,


### PR DESCRIPTION
## Summary

- **Dead code removed**: deleted empty `Primitive.kt`, dropped dead functions (`writeToCache` in FaviconFetcher, `extractBitmap` in WidgetCoverLoader), removed unused constants (`TYPE_IMAGE` in AppRouter, `totalSourcesCount` in RootSettingsViewModel)
- **Unused imports cleaned up**: removed `java.net.URI`, `Spring` class, `MangaSource` parser import, and 3 orphaned imports left behind after function deletions across 10+ files
- **Micro-optimisations**: `CACHE_CONTROL_NO_STORE` changed from lazy getter (new object every call) to eager `val`; `isSupportedMangaArchive` simplified to delegate to existing `isSupportedArchive()`; redundant no-op cache policy line removed from `ImageViewModel`
- **Style**: double blank lines removed across 15 files, mixed tab/space indentation fixed in `CommonHeadersInterceptor`, unused `context` parameter removed from `AppRouter.detailsActivityClass()`

## Test plan

- [ ] PR Preview Build passes and APK artifact is downloadable
- [ ] App launches and navigates normally (no missing class/function regressions)
- [ ] Settings → Storage & Network screen loads correctly
- [ ] Reader opens a chapter without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nzgbe9c6x8GYTnDWPW1gFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nzgbe9c6x8GYTnDWPW1gFR)_