### PR TITLE
Pre-release fixes: data-safety, sync, security & reader robustness

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,17 @@ plugins {
 	id 'org.jetbrains.kotlin.plugin.compose'
 }
 
+Properties properties = new Properties()
+File localPropertiesFile = project.rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+	properties.load(localPropertiesFile.newDataInputStream())
+}
+
+def shikimoriClientId = properties.getProperty("shikimori.clientId") ?: "Mw6F0tPEOgyV7F9U9Twg50Q8SndMY7hzIOfXg0AX_XU"
+def shikimoriClientSecret = properties.getProperty("shikimori.clientSecret") ?: "euBMt1GGRSDpVIFQVPxZrO7Kh6X4gWyv0dABuj4B-M8"
+def anilistClientId = properties.getProperty("anilist.clientId") ?: "9887"
+def anilistClientSecret = properties.getProperty("anilist.clientSecret") ?: "wrMqFosItQWsmB8dtAHfIFPDt15FfQi2ZGiKkJoW"
+
 android {
 	compileSdk {
 		version = release(37) {
@@ -21,7 +32,7 @@ android {
 	defaultConfig {
 		applicationId = 'org.haziffe.dropsauce'
 		minSdk = 23
-		targetSdk = 37
+		targetSdk = 35
 		versionCode = 45
 		versionName = '0.2.2'
 		testInstrumentationRunner = 'org.koitharu.kotatsu.HiltTestRunner'
@@ -32,14 +43,24 @@ android {
 			// https://issuetracker.google.com/issues/408030127
 			generateLocaleConfig = false
 		}
+		buildConfigField "String", "SHIKIMORI_CLIENT_ID", "\"${shikimoriClientId}\""
+		buildConfigField "String", "SHIKIMORI_CLIENT_SECRET", "\"${shikimoriClientSecret}\""
+		buildConfigField "String", "ANILIST_CLIENT_ID", "\"${anilistClientId}\""
+		buildConfigField "String", "ANILIST_CLIENT_SECRET", "\"${anilistClientSecret}\""
 	}
 	signingConfigs {
-		if (project.hasProperty('RELEASE_STORE_FILE')) {
-			release {
+		release {
+			if (project.hasProperty('RELEASE_STORE_FILE')) {
 				storeFile file(project.property('RELEASE_STORE_FILE'))
 				storePassword project.property('RELEASE_STORE_PASSWORD')
 				keyAlias project.property('RELEASE_KEY_ALIAS')
 				keyPassword project.property('RELEASE_KEY_PASSWORD')
+			} else {
+				// Fallback to debug signing config values so release signing configuration is always defined
+				storeFile file(System.getProperty("user.home") + "/.android/debug.keystore")
+				storePassword "android"
+				keyAlias "androiddebugkey"
+				keyPassword "android"
 			}
 		}
 	}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,9 +24,6 @@
 	<uses-permission
 		android:name="android.permission.WRITE_EXTERNAL_STORAGE"
 		android:maxSdkVersion="29" />
-	<uses-permission
-		android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-		tools:ignore="AllFilesAccessPolicy,ScopedStorage" />
 
 	<queries>
 		<intent>
@@ -40,7 +37,7 @@
 
 	<application
 		android:name="org.koitharu.kotatsu.KotatsuApp"
-		android:allowBackup="true"
+		android:allowBackup="false"
 		android:enableOnBackInvokedCallback="@bool/is_predictive_back_enabled"
 		android:hasFragileUserData="true"
 		android:restoreAnyVersion="true"
@@ -84,7 +81,7 @@
 
 				<data android:scheme="http" />
 				<data android:scheme="https" />
-				<data android:host="kotatsu.app" />
+				<data android:host="drop-sauce.app" />
 				<data android:path="/manga" />
 			</intent-filter>
 			<intent-filter>
@@ -93,9 +90,9 @@
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
 
-				<data android:scheme="kotatsu" />
+				<data android:scheme="dropsauce" />
 				<data android:host="manga" />
-				<data android:host="kotatsu.app" />
+				<data android:host="drop-sauce.app" />
 			</intent-filter>
 		</activity>
 		<activity
@@ -468,29 +465,9 @@
 				<data android:host="hitomi.la" />
 				<data android:host="imhentai.xxx" />
 				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
 				<data android:host="mangadex.org" />
 				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
-				<data android:host="mangafire.to" />
 				<data android:host="mangapark.net" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
-				<data android:host="mangaplus.shueisha.co.jp" />
 				<data android:host="mangaplus.shueisha.co.jp" />
 				<data android:host="mangareader.to" />
 				<data android:host="www.ninemanga.com" />
@@ -501,13 +478,6 @@
 				<data android:host="it.ninemanga.com" />
 				<data android:host="fr.ninemanga.com" />
 				<data android:host="animeh.to" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
-				<data android:host="webtoons.com" />
 				<data android:host="papscan.com" />
 				<data android:host="komikzoid.id" />
 				<data android:host="neumanga.xyz" />
@@ -561,7 +531,6 @@
 				<data android:host="legacy-scans.com" />
 				<data android:host="lire-scan.me" />
 				<data android:host="lugnica-scans.com" />
-				<data android:host="www.mangakawaii.io" />
 				<data android:host="www.manga-mana.com" />
 				<data android:host="scansmangas.me" />
 				<data android:host="scantrad-union.com" />
@@ -611,7 +580,6 @@
 				<data android:host="hentaicrot.com" />
 				<data android:host="pixhentai.com" />
 				<data android:host="mangagalaxy.org" />
-				<data android:host="vortextoon.com" />
 				<data android:host="vortextoon.com" />
 				<data android:host="nicovideo.jp" />
 				<data android:host="4uscans.com" />
@@ -733,7 +701,6 @@
 				<data android:host="madaradex.org" />
 				<data android:host="manga-1001.com" />
 				<data android:host="manga18.xyz" />
-				<data android:host="manga18h.xyz" />
 				<data android:host="manga18x.net" />
 				<data android:host="manga1k.com" />
 				<data android:host="manga1st.online" />
@@ -758,7 +725,6 @@
 				<data android:host="mangaleveling.com" />
 				<data android:host="mangaonlineteam.com" />
 				<data android:host="mangamaniacs.org" />
-				<data android:host="mangaonlineteam.com" />
 				<data android:host="mangaowlnet.com" />
 				<data android:host="mangaowl.io" />
 				<data android:host="mangaowlyaoi.com" />
@@ -766,7 +732,6 @@
 				<data android:host="mangaqueen.com" />
 				<data android:host="www.mangaread.org" />
 				<data android:host="mangaread.co" />
-				<data android:host="mangarockteam.com" />
 				<data android:host="mangarockteam.com" />
 				<data android:host="mangarolls.net" />
 				<data android:host="toon69.com" />
@@ -778,7 +743,6 @@
 				<data android:host="mangaempress.com" />
 				<data android:host="mangatyrant.com" />
 				<data android:host="mangaweebs.in" />
-				<data android:host="mangazin.org" />
 				<data android:host="toonclash.com" />
 				<data android:host="mangagg.com" />
 				<data android:host="mangaowl.one" />
@@ -919,7 +883,6 @@
 				<data android:host="visormonarca.com" />
 				<data android:host="mundomanhwa.com" />
 				<data android:host="www.swordalada.org" />
-				<data android:host="panconcola.com" />
 				<data android:host="ragnarokscan.com" />
 				<data android:host="ragnarokscanlation.net" />
 				<data android:host="richtoscan.com" />
@@ -965,7 +928,6 @@
 				<data android:host="pojokmanga.info" />
 				<data android:host="shinigami03.com" />
 				<data android:host="worldmanhwas.zone" />
-				<data android:host="www.xmanhwa.me" />
 				<data android:host="yubikiri.my.id" />
 				<data android:host="yuramanga.my.id" />
 				<data android:host="www.beyondtheataraxia.com" />
@@ -1168,7 +1130,6 @@
 				<data android:host="ww8.mangakakalot.tv" />
 				<data android:host="manganato.com" />
 				<data android:host="chapmanganato.to" />
-				<data android:host="chapmanganato.com" />
 				<data android:host="arc-relight.com" />
 				<data android:host="assortedscans.com" />
 				<data android:host="ar.areascans.org" />
@@ -1214,7 +1175,6 @@
 				<data android:host="hentai20.io" />
 				<data android:host="ponvi.online" />
 				<data android:host="komiklab.com" />
-				<data android:host="ponvi.online" />
 				<data android:host="radiantscans.com" />
 				<data android:host="lunarscan.org" />
 				<data android:host="mangagojo.com" />
@@ -1415,7 +1375,6 @@
 				<data android:host="summertoon.biz" />
 				<data android:host="www.tarotscans.com" />
 				<data android:host="tempestfansub.net" />
-				<data android:host="adumanga.com" />
 				<data android:host="tempestfansub.com" />
 				<data android:host="zenithscans.com" />
 				<data android:host="mangaworld.ac" />
@@ -1462,7 +1421,6 @@
 				<data android:host="snkscan.com" />
 				<data android:host="tokyorevengers.fr" />
 				<data android:host="vinlandsaga.fr" />
-				<data android:host="otakusan.net" />
 				<data android:host="otakusan.net" />
 				<data android:host="fmteam.fr" />
 				<data android:host="hni-scantrad.net" />
@@ -1517,8 +1475,6 @@
 				<data android:host="v2.yaoi-chan.me" />
 				<data android:host="v1.yaoi-chan.me" />
 				<data android:host="yaoi-chan.me" />
-				<data android:host="lib.social" />
-				<data android:host="lib.social" />
 				<data android:host="lib.social" />
 				<data android:host="www.mangafr.org" />
 				<data android:host="scan-trad.com" />

--- a/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/AutoFixUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/AutoFixUseCase.kt
@@ -48,13 +48,22 @@ class AutoFixUseCase @Inject constructor(
 		return seed to replacement
 	}
 
-	private suspend fun Manga.isHealthy(): Boolean = runCatchingCancellable {
-		val repo = mangaRepositoryFactory.create(source)
-		val details = if (this.chapters != null) this else repo.getDetails(this)
-		val firstChapter = details.chapters?.firstOrNull() ?: return@runCatchingCancellable false
-		val pageUrl = repo.getPageUrl(repo.getPages(firstChapter).first())
-		pageUrl.toHttpUrlOrNull() != null
-	}.getOrDefault(false)
+	private suspend fun Manga.isHealthy(): Boolean {
+		val result = runCatchingCancellable {
+			val repo = mangaRepositoryFactory.create(source)
+			val details = if (this.chapters != null) this else repo.getDetails(this)
+			val firstChapter = details.chapters?.firstOrNull() ?: return@runCatchingCancellable false
+			val pageUrl = repo.getPageUrl(repo.getPages(firstChapter).first())
+			pageUrl.toHttpUrlOrNull() != null
+		}
+		return result.getOrElse { e ->
+			if (e is java.io.IOException) {
+				true
+			} else {
+				false
+			}
+		}
+	}
 
 	private suspend fun Manga.getDetailsSafe() = runCatchingCancellable {
 		mangaRepositoryFactory.create(source).getDetails(this)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/MigrateUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/domain/MigrateUseCase.kt
@@ -1,5 +1,6 @@
 package org.koitharu.kotatsu.alternatives.domain
 
+import org.koitharu.kotatsu.parsers.util.longHashCode
 import androidx.room.withTransaction
 import org.koitharu.kotatsu.core.db.MangaDatabase
 import org.koitharu.kotatsu.core.model.getPreferredBranch
@@ -42,19 +43,65 @@ constructor(
 		} else {
 			newManga
 		}
+
 		mangaDataRepository.storeManga(newDetails, replaceExisting = true)
 		database.withTransaction {
 			// replace favorites
 			val favoritesDao = database.getFavouritesDao()
 			val oldFavourites = favoritesDao.findAllRaw(oldDetails.id)
+			val existingFavourites = favoritesDao.findAllRaw(newDetails.id)
+			val existingCategoryIds = existingFavourites.map { it.categoryId }.toSet()
 			if (oldFavourites.isNotEmpty()) {
 				favoritesDao.delete(oldManga.id)
 				for (f in oldFavourites) {
+					if (f.categoryId in existingCategoryIds) {
+						continue
+					}
 					val e =
 						f.copy(
-							mangaId = newManga.id,
+							mangaId = newDetails.id,
 						)
 					favoritesDao.upsert(e)
+				}
+			}
+			// replace bookmarks
+			val bookmarksDao = database.getBookmarksDao()
+			val oldBookmarks = bookmarksDao.findAll(oldDetails.id)
+			if (oldBookmarks.isNotEmpty()) {
+				for (bookmark in oldBookmarks) {
+					val oldChapters = oldDetails.chapters
+					val newChapters = newDetails.chapters
+					val oldChapter = oldChapters?.firstOrNull { it.id == bookmark.chapterId }
+					val newChapter = if (oldChapter != null && newChapters != null) {
+						val branch = oldChapter.branch
+						val newBranch = if (newChapters.any { it.branch == branch }) {
+							branch
+						} else {
+							newDetails.getPreferredBranch(null)
+						}
+						val newBranchChapters = newChapters.filter { it.branch == newBranch }
+						newBranchChapters.firstOrNull { it.volume == oldChapter.volume && it.number == oldChapter.number }
+							?: newBranchChapters.getOrNull(oldChapters.indexOf(oldChapter))
+							?: newBranchChapters.firstOrNull()
+					} else {
+						null
+					}
+					if (newChapter != null) {
+						bookmarksDao.delete(bookmark.pageId)
+						val newPageId = if (newDetails.source is org.koitharu.kotatsu.mihon.model.MihonMangaSource) {
+							val mihonSource = newDetails.source as org.koitharu.kotatsu.mihon.model.MihonMangaSource
+							val sourceKey = "mihon:${mihonSource.pkgName}:${mihonSource.catalogueSource.name}"
+							"$sourceKey|page|${newChapter.url}|${bookmark.page}".longHashCode()
+						} else {
+							"${newDetails.id}|${newChapter.id}|${bookmark.page}".longHashCode()
+						}
+						val newBookmark = bookmark.copy(
+							mangaId = newDetails.id,
+							pageId = newPageId,
+							chapterId = newChapter.id,
+						)
+						bookmarksDao.insert(newBookmark)
+					}
 				}
 			}
 			// replace history
@@ -114,7 +161,7 @@ constructor(
 				}
 			}
 		}
-		progressUpdateUseCase(newManga)
+		progressUpdateUseCase(newDetails)
 	}
 
 	private fun makeNewHistory(
@@ -125,6 +172,19 @@ constructor(
 		if (oldManga.chapters.isNullOrEmpty()) { // probably broken manga/source
 			val branch = newManga.getPreferredBranch(null)
 			val chapters = checkNotNull(newManga.getChapters(branch))
+			if (chapters.isEmpty()) {
+				return HistoryEntity(
+					mangaId = newManga.id,
+					createdAt = history.createdAt,
+					updatedAt = history.updatedAt,
+					chapterId = 0L,
+					page = history.page,
+					scroll = history.scroll,
+					percent = history.percent,
+					deletedAt = 0,
+					chaptersCount = 0,
+				)
+			}
 			val currentChapter =
 				if (history.percent in 0f..1f) {
 					chapters[(chapters.lastIndex * history.percent).toInt()]
@@ -175,7 +235,7 @@ constructor(
 			chapterId = newChapterId,
 			page = history.page,
 			scroll = history.scroll,
-			percent = PROGRESS_NONE,
+			percent = history.percent,
 			deletedAt = 0,
 			chaptersCount = checkNotNull(newChapters[newBranch]).size,
 		)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/ui/AutoFixService.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/alternatives/ui/AutoFixService.kt
@@ -15,6 +15,7 @@ import coil3.ImageLoader
 import coil3.request.ImageRequest
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.alternatives.domain.AutoFixUseCase
 import org.koitharu.kotatsu.alternatives.domain.AutoFixUseCase.NoAlternativesException
@@ -54,14 +55,37 @@ class AutoFixService : CoroutineIntentService() {
 	override suspend fun IntentJobContext.processIntent(intent: Intent) {
 		val ids = requireNotNull(intent.getLongArrayExtra(DATA_IDS))
 		startForeground(this)
-		for (mangaId in ids) {
+		val total = ids.size
+		for ((index, mangaId) in ids.withIndex()) {
+			if (checkNotificationPermission(CHANNEL_ID)) {
+				val title = getString(R.string.fixing_manga)
+				val progressNotification = NotificationCompat.Builder(this@AutoFixService, CHANNEL_ID)
+					.setContentTitle(title)
+					.setContentText("Processing ${index + 1} of $total")
+					.setPriority(NotificationCompat.PRIORITY_MIN)
+					.setDefaults(0)
+					.setSilent(true)
+					.setOngoing(true)
+					.setProgress(total, index + 1, false)
+					.setSmallIcon(R.drawable.general_notification)
+					.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+					.setCategory(NotificationCompat.CATEGORY_PROGRESS)
+					.addAction(
+						appcompatR.drawable.abc_ic_clear_material,
+						getString(android.R.string.cancel),
+						getCancelIntent(),
+					)
+					.build()
+				notificationManager.notify(FOREGROUND_NOTIFICATION_ID, progressNotification)
+			}
 			powerManager.withPartialWakeLock(TAG) {
 				val result = runCatchingCancellable {
 					autoFixUseCase.invoke(mangaId)
 				}
 				if (checkNotificationPermission(CHANNEL_ID)) {
-					val notification = buildNotification(startId, result)
-					notificationManager.notify(TAG, startId, notification)
+					val notificationId = (mangaId xor (mangaId ushr 32)).toInt()
+					val notification = buildNotification(notificationId, result)
+					notificationManager.notify(TAG, notificationId, notification)
 				}
 			}
 		}
@@ -69,8 +93,10 @@ class AutoFixService : CoroutineIntentService() {
 
 	override fun IntentJobContext.onError(error: Throwable) {
 		if (checkNotificationPermission(CHANNEL_ID)) {
-			val notification = runBlocking { buildNotification(startId, Result.failure(error)) }
-			notificationManager.notify(TAG, startId, notification)
+			launch {
+				val notification = buildNotification(startId, Result.failure(error))
+				notificationManager.notify(TAG, startId, notification)
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/MihonBackupManager.kt
@@ -113,15 +113,15 @@ class MihonBackupManager @Inject constructor(
         return withContext(Dispatchers.IO) {
             val backup = decode(uri)
             val diagnostics = buildDiagnostics(backup, options)
+            val restoredCategories = if (options.libraryEntries) {
+                db.withTransaction { restoreCategories() }
+            } else {
+                null
+            }
+            if (options.libraryEntries) {
+                restoreManga(backup, options, diagnostics, restoredCategories)
+            }
             db.withTransaction {
-                val restoredCategories = if (options.libraryEntries) {
-                    restoreCategories()
-                } else {
-                    null
-                }
-                if (options.libraryEntries) {
-                    restoreManga(backup, options, diagnostics, restoredCategories)
-                }
                 if (options.appSettings) {
                     restorePreferences(backup.backupPreferences)
                 }
@@ -199,19 +199,24 @@ class MihonBackupManager @Inject constructor(
 
     private suspend fun restoreCategories(): CategoryRestoreMapping {
         val dao = db.getFavouriteCategoriesDao()
-        val defaultCategoryId = dao.insert(
-            FavouriteCategoryEntity(
-                categoryId = 0,
-                createdAt = System.currentTimeMillis(),
-                sortKey = dao.getNextSortKey(),
-                title = "mihon",
-                order = "NEWEST",
-                track = true,
-                downloadNewChapters = false,
-                isVisibleInLibrary = true,
-                deletedAt = 0,
-            ),
-        )
+        val existing = dao.findByTitle("mihon")
+        val defaultCategoryId = if (existing != null) {
+            existing.categoryId.toLong()
+        } else {
+            dao.insert(
+                FavouriteCategoryEntity(
+                    categoryId = 0,
+                    createdAt = System.currentTimeMillis(),
+                    sortKey = dao.getNextSortKey(),
+                    title = "mihon",
+                    order = "NEWEST",
+                    track = true,
+                    downloadNewChapters = false,
+                    isVisibleInLibrary = true,
+                    deletedAt = 0,
+                ),
+            )
+        }
         return CategoryRestoreMapping(
             defaultCategoryId = defaultCategoryId,
         )
@@ -227,188 +232,195 @@ class MihonBackupManager @Inject constructor(
         val supportedTrackerIds = setOf(1, 2, 3, 4)
         val now = System.currentTimeMillis()
 
-        val pending = backup.backupManga.map { item ->
-            val sourceName = resolveStoredSourceName(item.source, backup.backupSources)
-            val mangaId = "$sourceName:${item.url}".longHashCode()
-            val tags = item.genre.mapNotNull { title ->
-                val clean = title.trim()
-                if (clean.isBlank()) {
-                    null
-                } else {
-                    TagEntity(
-                        id = "${clean.lowercase(Locale.ROOT)}:$sourceName".longHashCode(),
-                        title = clean,
-                        key = clean.lowercase(Locale.ROOT),
-                        source = sourceName,
-                        isPinned = false,
-                    )
-                }
-            }
-            val chapters = item.chapters.mapIndexed { index, chapter ->
-                ChapterEntity(
-                    chapterId = "$mangaId:${chapter.url}".longHashCode(),
-                    mangaId = mangaId,
-                    title = chapter.name,
-                    number = chapter.chapterNumber,
-                    volume = 0,
-                    url = chapter.url,
-                    scanlator = chapter.scanlator,
-                    uploadDate = chapter.dateUpload,
-                    branch = null,
-                    source = sourceName,
-                    index = chapter.sourceOrder.toInt().takeIf { it >= 0 } ?: index,
-                )
-            }
-            val categoryIds = if (item.favorite) {
-                listOfNotNull(defaultCategoryId)
-            } else {
-                emptyList()
-            }
-            val favourites = categoryIds.mapIndexed { sortIndex, categoryId ->
-                FavouriteEntity(
-                    mangaId = mangaId,
-                    categoryId = categoryId,
-                    sortKey = sortIndex,
-                    isPinned = false,
-                    createdAt = item.dateAdded.takeIf { it > 0 } ?: now,
-                    deletedAt = 0,
-                )
-            }
-            val chapterByUrl = chapters.associateBy { it.url }
-            val bookmarks = item.chapters.asSequence()
-                .filter { it.bookmark }
-                .mapNotNull { chapter ->
-                    val chapterEntity = chapterByUrl[chapter.url] ?: return@mapNotNull null
-                    val page = chapter.lastPageRead.toInt().coerceAtLeast(0)
-                    BookmarkEntity(
-                        mangaId = mangaId,
-                        pageId = "$mangaId:${chapter.url}:$page".longHashCode(),
-                        chapterId = chapterEntity.chapterId,
-                        page = page,
-                        scroll = 0,
-                        imageUrl = "",
-                        createdAt = now,
-                        percent = 0f,
-                    )
-                }
-                .toList()
-
-            val historyItem = item.history.maxByOrNull { it.lastRead }
-            val fallbackReadChapter = item.chapters.withIndex().lastOrNull { it.value.read }
-            val historyChapterUrl = historyItem?.url ?: fallbackReadChapter?.value?.url
-            val historyChapter = historyChapterUrl?.let(chapterByUrl::get)
-                ?: fallbackReadChapter?.let { chapters.getOrNull(it.index) }
-            val history = if (historyChapter != null) {
-                val backupChapter = item.chapters.firstOrNull { it.url == historyChapter.url }
-                val restoredPage = backupChapter?.lastPageRead?.toInt()?.coerceAtLeast(0) ?: 0
-                val chapterIndex = chapters.indexOfFirst { it.chapterId == historyChapter.chapterId }
-                    .takeIf { it >= 0 }
-                    ?: 0
-                val updatedAt = historyItem?.lastRead?.takeIf { it > 0 }
-                    ?: item.dateAdded.takeIf { it > 0 }
-                    ?: now
-                HistoryEntity(
-                    mangaId = mangaId,
-                    createdAt = updatedAt,
-                    updatedAt = updatedAt,
-                    chapterId = historyChapter.chapterId,
-                    page = restoredPage,
-                    scroll = 0f,
-                    percent = computeHistoryPercent(
-                        chapterIndex = chapterIndex,
-                        chaptersCount = chapters.size,
-                    ),
-                    deletedAt = 0,
-                    chaptersCount = chapters.size,
-                )
-            } else {
-                null
-            }
-            val stats = if ((historyItem?.readDuration ?: 0L) > 0L && history != null) {
-                StatsEntity(
-                    mangaId = mangaId,
-                    startedAt = (history.updatedAt - historyItem!!.readDuration).coerceAtLeast(0L),
-                    duration = historyItem.readDuration,
-                    pages = (history.page + 1).coerceAtLeast(1),
-                )
-            } else {
-                null
-            }
-            val scrobblings = if (options.tracking) {
-                item.tracking.mapNotNull { tracking ->
-                    if (tracking.syncId !in supportedTrackerIds) {
-                        diagnostics.missingTrackers += tracking.syncId
-                        return@mapNotNull null
+        backup.backupManga.chunked(50).forEach { batch ->
+            val pendingBatch = batch.map { item ->
+                val sourceName = resolveStoredSourceName(item.source, backup.backupSources)
+                val mangaId = "$sourceName|manga|${item.url}".longHashCode()
+                val tags = item.genre.mapNotNull { title ->
+                    val clean = title.trim()
+                    if (clean.isBlank()) {
+                        null
+                    } else {
+                        TagEntity(
+                            id = "${clean.lowercase(Locale.ROOT)}_${sourceName}".longHashCode(),
+                            title = clean,
+                            key = clean.lowercase(Locale.ROOT),
+                            source = sourceName,
+                            isPinned = false,
+                        )
                     }
-                    val targetId = tracking.mediaId.takeIf { it > 0 }
-                        ?: tracking.mediaIdInt.toLong().takeIf { it > 0 }
-                        ?: return@mapNotNull null
-                    val remoteEntryId = tracking.libraryId.toInt().takeIf { it > 0 }
-                        ?: targetId.toInt().takeIf { it > 0 }
-                        ?: return@mapNotNull null
-                    ScrobblingEntity(
-                        scrobbler = tracking.syncId,
-                        id = remoteEntryId,
+                }
+                val chapters = item.chapters.mapIndexed { index, chapter ->
+                    ChapterEntity(
+                        chapterId = "$sourceName|chapter|${chapter.url}".longHashCode(),
                         mangaId = mangaId,
-                        targetId = targetId,
-                        status = decodeTrackingStatus(tracking.status),
-                        chapter = tracking.lastChapterRead.toInt().coerceAtLeast(0),
-                        comment = null,
-                        rating = tracking.score,
+                        title = chapter.name,
+                        number = chapter.chapterNumber,
+                        volume = 0,
+                        url = chapter.url,
+                        scanlator = chapter.scanlator,
+                        uploadDate = chapter.dateUpload,
+                        branch = null,
+                        source = sourceName,
+                        index = index,
                     )
                 }
-            } else {
-                emptyList()
+                val categoryIds = if (item.favorite) {
+                    listOfNotNull(defaultCategoryId)
+                } else {
+                    emptyList()
+                }
+                val favourites = categoryIds.mapIndexed { sortIndex, categoryId ->
+                    FavouriteEntity(
+                        mangaId = mangaId,
+                        categoryId = categoryId,
+                        sortKey = sortIndex,
+                        isPinned = false,
+                        createdAt = item.dateAdded.takeIf { it > 0 } ?: now,
+                        deletedAt = 0,
+                    )
+                }
+                val chapterByUrl = chapters.associateBy { it.url }
+                val bookmarks = item.chapters.asSequence()
+                    .filter { it.bookmark }
+                    .mapNotNull { chapter ->
+                        val chapterEntity = chapterByUrl[chapter.url] ?: return@mapNotNull null
+                        val page = chapter.lastPageRead.toInt().coerceAtLeast(0)
+                        BookmarkEntity(
+                            mangaId = mangaId,
+                            pageId = "$sourceName|page|${chapter.url}|$page".longHashCode(),
+                            chapterId = chapterEntity.chapterId,
+                            page = page,
+                            scroll = 0,
+                            imageUrl = "",
+                            createdAt = now,
+                            percent = 0f,
+                        )
+                    }
+                    .toList()
+
+                val historyItem = item.history.maxByOrNull { it.lastRead }
+                val fallbackReadChapter = item.chapters.withIndex().lastOrNull { it.value.read }
+                val historyChapterUrl = historyItem?.url ?: fallbackReadChapter?.value?.url
+                val historyChapter = historyChapterUrl?.let(chapterByUrl::get)
+                    ?: fallbackReadChapter?.let { chapters.getOrNull(it.index) }
+                val history = if (historyChapter != null) {
+                    val backupChapter = item.chapters.firstOrNull { it.url == historyChapter.url }
+                    val restoredPage = backupChapter?.lastPageRead?.toInt()?.coerceAtLeast(0) ?: 0
+                    val chapterIndex = chapters.indexOfFirst { it.chapterId == historyChapter.chapterId }
+                        .takeIf { it >= 0 }
+                        ?: 0
+                    val updatedAt = historyItem?.lastRead?.takeIf { it > 0 }
+                        ?: item.dateAdded.takeIf { it > 0 }
+                        ?: now
+                    HistoryEntity(
+                        mangaId = mangaId,
+                        createdAt = updatedAt,
+                        updatedAt = updatedAt,
+                        chapterId = historyChapter.chapterId,
+                        page = restoredPage,
+                        scroll = 0f,
+                        percent = computeHistoryPercent(
+                            chapterIndex = chapterIndex,
+                            chaptersCount = chapters.size,
+                        ),
+                        deletedAt = 0,
+                        chaptersCount = chapters.size,
+                    )
+                } else {
+                    null
+                }
+                val stats = if ((historyItem?.readDuration ?: 0L) > 0L && history != null) {
+                    StatsEntity(
+                        mangaId = mangaId,
+                        startedAt = (history.updatedAt - historyItem!!.readDuration).coerceAtLeast(0L),
+                        duration = historyItem.readDuration,
+                        pages = (history.page + 1).coerceAtLeast(1),
+                    )
+                } else {
+                    null
+                }
+                val scrobblings = if (options.tracking) {
+                    item.tracking.mapNotNull { tracking ->
+                        if (tracking.syncId !in supportedTrackerIds) {
+                            diagnostics.missingTrackers += tracking.syncId
+                            return@mapNotNull null
+                        }
+                        val targetId = tracking.mediaId.takeIf { it > 0 }
+                            ?: tracking.mediaIdInt.toLong().takeIf { it > 0 }
+                            ?: return@mapNotNull null
+                        val remoteEntryId = tracking.libraryId.toInt().takeIf { it > 0 }
+                            ?: targetId.toInt().takeIf { it > 0 }
+                            ?: return@mapNotNull null
+                        ScrobblingEntity(
+                            scrobbler = tracking.syncId,
+                            id = remoteEntryId,
+                            mangaId = mangaId,
+                            targetId = targetId,
+                            status = decodeTrackingStatus(tracking.status),
+                            chapter = tracking.lastChapterRead.toInt().coerceAtLeast(0),
+                            comment = null,
+                            rating = tracking.score,
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
+
+                PendingRestore(
+                    manga = MangaEntity(
+                        id = mangaId,
+                        title = item.title,
+                        altTitles = null,
+                        url = item.url,
+                        publicUrl = item.url,
+                        rating = -1f,
+                        isNsfw = false,
+                        contentRating = null,
+                        coverUrl = item.thumbnailUrl.orEmpty(),
+                        largeCoverUrl = null,
+                        state = null,
+                        authors = item.author,
+                        source = sourceName,
+                        sourceTitle = resolveSourceTitle(item.source, backup.backupSources),
+                    ),
+                    tags = tags,
+                    chapters = chapters,
+                    favourites = favourites,
+                    history = history,
+                    stats = stats,
+                    bookmarks = bookmarks,
+                    scrobblings = scrobblings,
+                )
             }
 
-            PendingRestore(
-                manga = MangaEntity(
-                    id = mangaId,
-                    title = item.title,
-                    altTitles = null,
-                    url = item.url,
-                    publicUrl = item.url,
-                    rating = -1f,
-                    isNsfw = false,
-                    contentRating = null,
-                    coverUrl = item.thumbnailUrl.orEmpty(),
-                    largeCoverUrl = null,
-                    state = null,
-                    authors = item.author,
-                    source = sourceName,
-                    sourceTitle = resolveSourceTitle(item.source, backup.backupSources),
-                ),
-                tags = tags,
-                chapters = chapters,
-                favourites = favourites,
-                history = history,
-                stats = stats,
-                bookmarks = bookmarks,
-                scrobblings = scrobblings,
-            )
-        }
-
-        pending.flatMapTo(linkedSetOf()) { it.tags }
-            .takeIf { it.isNotEmpty() }
-            ?.let { db.getTagsDao().upsert(it.toList()) }
-        pending.forEach { item -> db.getMangaDao().upsert(item.manga, item.tags) }
-        pending.forEach { item -> item.favourites.forEach { db.getFavouritesDao().upsert(it) } }
-        pending.forEach { item -> db.getChaptersDao().replaceAll(item.manga.id, item.chapters) }
-        pending.forEach { item -> item.history?.let { db.getHistoryDao().upsert(it) } }
-        pending.forEach { item -> item.stats?.let { db.getStatsDao().upsert(it) } }
-        pending.forEach { item ->
-            if (item.bookmarks.isNotEmpty()) {
-                db.getBookmarksDao().upsert(item.bookmarks)
+            db.withTransaction {
+                pendingBatch.flatMapTo(linkedSetOf()) { it.tags }
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { db.getTagsDao().upsert(it.toList()) }
+                pendingBatch.forEach { item -> db.getMangaDao().upsert(item.manga, item.tags) }
+                pendingBatch.forEach { item -> item.favourites.forEach { db.getFavouritesDao().upsert(it) } }
+                pendingBatch.forEach { item ->
+                    if (item.chapters.isNotEmpty()) {
+                        db.getChaptersDao().replaceAll(item.manga.id, item.chapters)
+                    }
+                }
+                pendingBatch.forEach { item -> item.history?.let { db.getHistoryDao().upsert(it) } }
+                pendingBatch.forEach { item -> item.stats?.let { db.getStatsDao().upsert(it) } }
+                pendingBatch.forEach { item ->
+                    if (item.bookmarks.isNotEmpty()) {
+                        db.getBookmarksDao().upsert(item.bookmarks)
+                    }
+                }
+                pendingBatch.forEach { item ->
+                    item.scrobblings.forEach {
+                        db.getScrobblingDao().upsert(it)
+                        diagnostics.restoredTrackingCount += 1
+                    }
+                }
             }
+            diagnostics.restoredMangaCount += pendingBatch.size
         }
-        pending.forEach { item ->
-            item.scrobblings.forEach {
-                db.getScrobblingDao().upsert(it)
-                diagnostics.restoredTrackingCount += 1
-            }
-        }
-
-        diagnostics.restoredMangaCount += pending.size
     }
 
     private fun restorePreferences(preferences: List<MihonBackupPreference>) {
@@ -455,9 +467,11 @@ class MihonBackupManager @Inject constructor(
     private fun resolveStoredSourceName(sourceId: Long, backupSources: List<MihonBackupSource>): String {
         val source = mihonExtensionManager.getMihonMangaSourceById(sourceId)
         if (source != null) {
-            return source.name
+            return "mihon:${source.pkgName}:${source.catalogueSource.name}"
         }
-        return if (sourceId > 0) "MIHON_$sourceId" else "UNKNOWN"
+        val backupSource = backupSources.firstOrNull { it.sourceId == sourceId }
+        val name = backupSource?.name ?: "UNKNOWN"
+        return "mihon:unknown:$name"
     }
 
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/data/LocalBackupRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/data/LocalBackupRepository.kt
@@ -171,7 +171,16 @@ class LocalBackupRepository @Inject constructor(
 
 					BackupSection.HISTORY -> input.readJsonArray<HistoryBackup>(serializer()).restoreToDb {
 						upsertMangaBackup(it.manga)
-						getHistoryDao().upsert(it.toEntity())
+						val backupEntity = it.toEntity()
+						val existing = getHistoryDao().findRaw(backupEntity.mangaId)
+						if (existing == null) {
+							getHistoryDao().upsert(backupEntity)
+						} else {
+							val existingTime = maxOf(existing.updatedAt, existing.deletedAt)
+							if (backupEntity.updatedAt > existingTime) {
+								getHistoryDao().upsert(backupEntity)
+							}
+						}
 					}
 
 					BackupSection.CATEGORIES -> input.readJsonArray<CategoryBackup>(serializer()).restoreToDb {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/data/model/BackupModels.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/data/model/BackupModels.kt
@@ -353,6 +353,7 @@ class ScrobblingBackup(
 	@SerialName("chapter") val chapter: Int = 0,
 	@SerialName("comment") val comment: String? = null,
 	@SerialName("rating") val rating: Float = 0f,
+	@SerialName("updated_at") val updatedAt: Long = 0L,
 ) {
 
 	constructor(entity: ScrobblingEntity) : this(
@@ -364,6 +365,7 @@ class ScrobblingBackup(
 		chapter = entity.chapter,
 		comment = entity.comment,
 		rating = entity.rating,
+		updatedAt = entity.updatedAt,
 	)
 
 	fun toEntity() = ScrobblingEntity(
@@ -375,6 +377,7 @@ class ScrobblingBackup(
 		chapter = chapter,
 		comment = comment,
 		rating = rating,
+		updatedAt = updatedAt,
 	)
 }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -98,14 +98,6 @@ open class BaseApp : Application(), Configuration.Provider {
 		initAcra {
 			buildConfigClass = BuildConfig::class.java
 			reportFormat = StringFormat.JSON
-			
-			dialog {
-				text = getString(R.string.crash_text)
-				title = getString(R.string.error_occurred)
-				positiveButtonText = getString(R.string.close)
-				resIcon = R.drawable.ic_alert_outline
-				resTheme = android.R.style.Theme_Material_Light_Dialog_Alert
-			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/MangaDatabase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/MangaDatabase.kt
@@ -47,6 +47,7 @@ import org.koitharu.kotatsu.core.db.migrations.Migration26To27
 import org.koitharu.kotatsu.core.db.migrations.Migration27To28
 import org.koitharu.kotatsu.core.db.migrations.Migration28To29
 import org.koitharu.kotatsu.core.db.migrations.Migration29To30
+import org.koitharu.kotatsu.core.db.migrations.Migration30To31
 import org.koitharu.kotatsu.core.db.migrations.Migration2To3
 import org.koitharu.kotatsu.core.db.migrations.Migration3To4
 import org.koitharu.kotatsu.core.db.migrations.Migration4To5
@@ -74,7 +75,7 @@ import org.koitharu.kotatsu.tracker.data.TrackEntity
 import org.koitharu.kotatsu.tracker.data.TrackLogEntity
 import org.koitharu.kotatsu.tracker.data.TracksDao
 
-const val DATABASE_VERSION = 30
+const val DATABASE_VERSION = 31
 
 @Database(
 	entities = [
@@ -149,6 +150,7 @@ fun getDatabaseMigrations(context: Context): Array<Migration> = arrayOf(
 	Migration27To28(),
 	Migration28To29(),
 	Migration29To30(),
+	Migration30To31(),
 )
 
 fun MangaDatabase(context: Context): MangaDatabase = Room

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/migrations/Migration30To31.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/migrations/Migration30To31.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.core.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration30To31 : Migration(30, 31) {
+
+	override fun migrate(db: SupportSQLiteDatabase) {
+		db.execSQL("ALTER TABLE scrobblings ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0")
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/resolve/ExceptionResolver.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/resolve/ExceptionResolver.kt
@@ -1,5 +1,6 @@
 package org.koitharu.kotatsu.core.exceptions.resolve
 
+import org.koitharu.kotatsu.BuildConfig
 import android.content.Context
 import android.widget.Toast
 import androidx.activity.result.ActivityResultCaller
@@ -147,14 +148,24 @@ class ExceptionResolver private constructor(
 
     private fun showSslErrorDialog() {
         val ctx = host.context ?: return
+        if (!BuildConfig.DEBUG) {
+            return
+        }
         if (settings.isSSLBypassEnabled) {
             Toast.makeText(ctx, R.string.operation_not_supported, Toast.LENGTH_SHORT).show()
             return
         }
+        val targetHost = settings.lastSslFailedHost
         buildAlertDialog(ctx) {
             setTitle(R.string.ignore_ssl_errors)
-            setMessage(R.string.ignore_ssl_errors_summary)
+            val message = if (targetHost != null) {
+                "Ignore SSL errors for $targetHost? This is insecure and should only be used for debugging."
+            } else {
+                ctx.getString(R.string.ignore_ssl_errors_summary)
+            }
+            setMessage(message)
             setPositiveButton(R.string.apply) { _, _ ->
+                settings.sslBypassHost = targetHost
                 settings.isSSLBypassEnabled = true
                 Toast.makeText(ctx, R.string.settings_apply_restart_required, Toast.LENGTH_LONG).show()
                 ctx.restartApplication()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/model/Manga.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/model/Manga.kt
@@ -115,7 +115,7 @@ val Manga.isBroken: Boolean
 	get() = source == UnknownMangaSource
 
 val Manga.appUrl: Uri
-	get() = "https://kotatsu.app/manga".toUri()
+	get() = "https://drop-sauce.app/manga".toUri()
 		.buildUpon()
 		.appendQueryParameter("source", source.name)
 		.appendQueryParameter("name", title)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/NetworkModule.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/NetworkModule.kt
@@ -73,12 +73,25 @@ interface NetworkModule {
 			proxySelector(proxyProvider.selector)
 			proxyAuthenticator(proxyProvider.authenticator)
 			dns(DoHManager(cache, settings))
-			if (settings.isSSLBypassEnabled) {
-				disableCertificateVerification()
+			if (settings.isSSLBypassEnabled && BuildConfig.DEBUG) {
+				disableCertificateVerification(contextProvider.get(), settings.sslBypassHost)
 			} else {
 				installExtraCertificates(contextProvider.get())
 			}
 			cache(cache)
+			addInterceptor { chain ->
+				try {
+					chain.proceed(chain.request())
+				} catch (e: Exception) {
+					if (e is javax.net.ssl.SSLException || e is java.security.cert.CertPathValidatorException ||
+						e.cause is javax.net.ssl.SSLException || e.cause is java.security.cert.CertPathValidatorException) {
+						if (BuildConfig.DEBUG) {
+							settings.lastSslFailedHost = chain.request().url.host
+						}
+					}
+					throw e
+				}
+			}
 			addInterceptor(GZipInterceptor())
 			addInterceptor(CloudFlareInterceptor())
 			addInterceptor(RateLimitInterceptor())

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/SSLUtils.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/SSLUtils.kt
@@ -15,21 +15,121 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
 @SuppressLint("CustomX509TrustManager")
-fun OkHttpClient.Builder.disableCertificateVerification() = also { builder ->
-	runCatching {
-		val trustAllCerts = object : X509TrustManager {
-			override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+class ScopedTrustManager(
+	private val delegate: javax.net.ssl.X509ExtendedTrustManager?,
+	private val bypassHost: String?
+) : javax.net.ssl.X509ExtendedTrustManager() {
 
-			override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+	override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+		delegate?.checkClientTrusted(chain, authType)
+	}
 
-			override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+	override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+		delegate?.checkServerTrusted(chain, authType)
+	}
+
+	override fun getAcceptedIssuers(): Array<X509Certificate> {
+		return delegate?.acceptedIssuers ?: emptyArray()
+	}
+
+	override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: java.net.Socket?) {
+		delegate?.checkClientTrusted(chain, authType, socket)
+	}
+
+	override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: javax.net.ssl.SSLEngine?) {
+		delegate?.checkClientTrusted(chain, authType, engine)
+	}
+
+	override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: java.net.Socket?) {
+		val host = getHost(socket)
+		if (BuildConfig.DEBUG && !bypassHost.isNullOrEmpty() && host != null &&
+			(host.equals(bypassHost, ignoreCase = true) || host.endsWith(".$bypassHost", ignoreCase = true))) {
+			return
 		}
-		val sslContext = SSLContext.getInstance("SSL")
-		sslContext.init(null, arrayOf(trustAllCerts), SecureRandom())
+		delegate?.checkServerTrusted(chain, authType, socket)
+	}
+
+	override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: javax.net.ssl.SSLEngine?) {
+		val host = engine?.peerHost
+		if (BuildConfig.DEBUG && !bypassHost.isNullOrEmpty() && host != null &&
+			(host.equals(bypassHost, ignoreCase = true) || host.endsWith(".$bypassHost", ignoreCase = true))) {
+			return
+		}
+		delegate?.checkServerTrusted(chain, authType, engine)
+	}
+
+	private fun getHost(socket: java.net.Socket?): String? {
+		if (socket is javax.net.ssl.SSLSocket) {
+			runCatching { return socket.handshakeSession?.peerHost }.getOrNull()
+				?: runCatching { return socket.session.peerHost }.getOrNull()
+		}
+		return socket?.inetAddress?.hostName
+	}
+}
+
+private fun showSslWarningNotification(context: Context, host: String) {
+	val channelId = "ssl_bypass_channel"
+	val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+		val channel = NotificationChannel(
+			channelId,
+			"SSL Bypass Warning",
+			NotificationManager.IMPORTANCE_HIGH
+		).apply {
+			description = "Warning that SSL certificate verification is bypassed for a host"
+		}
+		notificationManager.createNotificationChannel(channel)
+	}
+	val notification = NotificationCompat.Builder(context, channelId)
+		.setSmallIcon(android.R.drawable.stat_sys_warning)
+		.setContentTitle("SSL Verification Bypassed")
+		.setContentText("Certificate check disabled for $host")
+		.setOngoing(true)
+		.setPriority(NotificationCompat.PRIORITY_HIGH)
+		.build()
+	notificationManager.notify(1001, notification)
+}
+
+private fun cancelSslWarningNotification(context: Context) {
+	val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+	notificationManager.cancel(1001)
+}
+
+@SuppressLint("CustomX509TrustManager")
+fun OkHttpClient.Builder.disableCertificateVerification(context: Context, bypassHost: String?) = also { builder ->
+	if (!BuildConfig.DEBUG) return@also
+	runCatching {
+		val trustManagerFactory = javax.net.ssl.TrustManagerFactory.getInstance(javax.net.ssl.TrustManagerFactory.getDefaultAlgorithm())
+		trustManagerFactory.init(null as java.security.KeyStore?)
+		val defaultTrustManager = trustManagerFactory.trustManagers.first { it is X509TrustManager } as X509TrustManager
+		val extendedTrustManager = defaultTrustManager as? javax.net.ssl.X509ExtendedTrustManager
+
+		val trustManager = ScopedTrustManager(extendedTrustManager, bypassHost)
+		val sslContext = javax.net.ssl.SSLContext.getInstance("TLS")
+		sslContext.init(null, arrayOf(trustManager), java.security.SecureRandom())
 		val sslSocketFactory: SSLSocketFactory = sslContext.socketFactory
-		builder.sslSocketFactory(sslSocketFactory, trustAllCerts)
-		builder.hostnameVerifier { _, _ -> true }
+		builder.sslSocketFactory(sslSocketFactory, trustManager)
+
+		val defaultVerifier = javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier()
+		builder.hostnameVerifier { hostname, session ->
+			if (!bypassHost.isNullOrEmpty() && (hostname.equals(bypassHost, ignoreCase = true) || hostname.endsWith(".$bypassHost", ignoreCase = true))) {
+				true
+			} else {
+				defaultVerifier.verify(hostname, session)
+			}
+		}
+
+		if (!bypassHost.isNullOrEmpty()) {
+			showSslWarningNotification(context, bypassHost)
+		} else {
+			cancelSslWarningNotification(context)
+		}
 	}.onFailure {
 		it.printStackTraceDebug()
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/MangaLinkResolver.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/MangaLinkResolver.kt
@@ -25,7 +25,7 @@ class MangaLinkResolver @Inject constructor(
 ) {
 
 	suspend fun resolve(uri: Uri): Manga {
-		return if (uri.scheme == "kotatsu" || uri.host == "kotatsu.app") {
+		return if (uri.scheme == "kotatsu" || uri.scheme == "dropsauce" || uri.host == "kotatsu.app" || uri.host == "drop-sauce.app") {
 			resolveAppLink(uri)
 		} else {
 			resolveExternalLink(uri.toString())

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -593,6 +593,14 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		get() = prefs.getBoolean(KEY_SSL_BYPASS, false)
 		set(value) = prefs.edit { putBoolean(KEY_SSL_BYPASS, value) }
 
+	var sslBypassHost: String?
+		get() = prefs.getString(KEY_SSL_BYPASS_HOST, null)
+		set(value) = prefs.edit { putString(KEY_SSL_BYPASS_HOST, value) }
+
+	var lastSslFailedHost: String?
+		get() = prefs.getString(KEY_LAST_SSL_FAILED_HOST, null)
+		set(value) = prefs.edit { putString(KEY_LAST_SSL_FAILED_HOST, value) }
+
 	val proxyType: Proxy.Type
 		get() {
 			val raw = prefs.getString(KEY_PROXY_TYPE, null) ?: return Proxy.Type.DIRECT
@@ -918,6 +926,8 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_SOURCES_GRID = "sources_grid"
 		const val KEY_TIPS_CLOSED = "tips_closed"
 		const val KEY_SSL_BYPASS = "ssl_bypass"
+		const val KEY_SSL_BYPASS_HOST = "ssl_bypass_host"
+		const val KEY_LAST_SSL_FAILED_HOST = "last_ssl_failed_host"
 		const val KEY_READER_AUTOSCROLL_SPEED = "as_speed"
 		const val KEY_READER_AUTOSCROLL_FAB = "as_fab"
 		const val KEY_MIRROR_SWITCHING = "mirror_switching"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/ColorScheme.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/ColorScheme.kt
@@ -14,8 +14,8 @@ enum class ColorScheme(
 ) {
 
 	DEFAULT(R.style.ThemeOverlay_Kotatsu_Totoro, R.string.theme_name_totoro),
-	MONET(R.style.ThemeOverlay_Kotatsu_Monet, R.string.theme_name_dynamic),
 	EXPRESSIVE(R.style.ThemeOverlay_Kotatsu_Expressive, R.string.theme_name_expressive),
+	MONET(R.style.ThemeOverlay_Kotatsu_Monet, R.string.theme_name_dynamic),
 	MIKU(R.style.ThemeOverlay_Kotatsu_Miku, R.string.theme_name_miku),
 	RENA(R.style.ThemeOverlay_Kotatsu_Asuka, R.string.theme_name_asuka),
 	FROG(R.style.ThemeOverlay_Kotatsu_Mion, R.string.theme_name_mion),

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsExpressiveActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsExpressiveActivity.kt
@@ -154,6 +154,7 @@ class DetailsExpressiveActivity :
 			onIncognitoClick = { openReader(isIncognitoMode = true) },
 			onForgetHistoryClick = { viewModel.removeFromHistory() },
 			onChaptersClick = { router.showChapterPagesSheet() },
+			onRetry = { viewModel.reload() },
 		)
 		viewBinding.composeView.setViewCompositionStrategy(
 			ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsExpressiveScreen.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsExpressiveScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -128,6 +130,7 @@ class DetailsExpressiveActions(
 	val onIncognitoClick: () -> Unit,
 	val onForgetHistoryClick: () -> Unit,
 	val onChaptersClick: () -> Unit,
+	val onRetry: () -> Unit = {},
 )
 
 private val SCREEN_PADDING = 20.dp
@@ -201,7 +204,11 @@ fun DetailsExpressiveScreen(
 			Spacer(Modifier.height(topInset + if (centered) 84.dp else 72.dp))
 
 			if (manga == null) {
-				LoadingHero()
+				if (isLoading) {
+					LoadingHero()
+				} else {
+					ErrorHero(onRetry = actions.onRetry)
+				}
 			} else {
 				val favLabel = favouriteLabel ?: stringResource(R.string.add_to_favourites)
 				val isFavourite = favouriteCount > 0
@@ -1496,6 +1503,36 @@ private fun LoadingHero() {
 			style = MaterialTheme.typography.titleMedium,
 			color = MaterialTheme.colorScheme.onSurfaceVariant,
 		)
+	}
+}
+
+@Composable
+private fun ErrorHero(onRetry: () -> Unit) {
+	Box(
+		modifier = Modifier
+			.fillMaxWidth()
+			.height(240.dp),
+		contentAlignment = Alignment.Center,
+	) {
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+			verticalArrangement = Arrangement.spacedBy(12.dp)
+		) {
+			Text(
+				text = stringResource(R.string.error_occurred),
+				style = MaterialTheme.typography.titleMedium,
+				color = MaterialTheme.colorScheme.error,
+			)
+			Button(
+				onClick = onRetry,
+				colors = ButtonDefaults.buttonColors(
+					containerColor = MaterialTheme.colorScheme.errorContainer,
+					contentColor = MaterialTheme.colorScheme.onErrorContainer
+				)
+			) {
+				Text(text = stringResource(R.string.retry))
+			}
+		}
 	}
 }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/ui/DetailsViewModel.kt
@@ -141,6 +141,7 @@ class DetailsViewModel @Inject constructor(
 		}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.WhileSubscribed(5000), 0L)
 
 	val cachedSourceTitle = mangaDetails
+		.distinctUntilChanged { a, b -> a?.id == b?.id }
 		.mapLatest { details ->
 			if (details == null) null else database.getMangaDao().findSourceTitle(mangaId)
 		}
@@ -153,16 +154,18 @@ class DetailsViewModel @Inject constructor(
 		.withErrorHandling()
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, emptyList())
 
-	val relatedManga: StateFlow<List<MangaListModel>> = manga.mapLatest {
-		if (it != null && settings.isRelatedMangaEnabled) {
-			mangaListMapper.toListModelList(
-				manga = relatedMangaUseCase(it).orEmpty(),
-				mode = ListMode.GRID,
-			)
-		} else {
-			emptyList()
-		}
-	}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Lazily, emptyList())
+	val relatedManga: StateFlow<List<MangaListModel>> = manga
+		.distinctUntilChanged { a, b -> a?.id == b?.id }
+		.mapLatest {
+			if (it != null && settings.isRelatedMangaEnabled) {
+				mangaListMapper.toListModelList(
+					manga = relatedMangaUseCase(it).orEmpty(),
+					mode = ListMode.GRID,
+				)
+			} else {
+				emptyList()
+			}
+		}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Lazily, emptyList())
 
 	val tags = manga.mapLatest {
 		mangaListMapper.mapTags(it?.tags.orEmpty())

--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouriteCategoriesDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/data/FavouriteCategoriesDao.kt
@@ -14,6 +14,9 @@ abstract class FavouriteCategoriesDao {
 	@Query("SELECT * FROM favourite_categories WHERE category_id = :id AND deleted_at = 0")
 	abstract suspend fun find(id: Int): FavouriteCategoryEntity
 
+	@Query("SELECT * FROM favourite_categories WHERE title = :title AND deleted_at = 0 LIMIT 1")
+	abstract suspend fun findByTitle(title: String): FavouriteCategoryEntity?
+
 	@Query("SELECT * FROM favourite_categories WHERE deleted_at = 0 ORDER BY sort_key")
 	abstract suspend fun findAll(): List<FavouriteCategoryEntity>
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/history/data/HistoryDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/history/data/HistoryDao.kt
@@ -97,6 +97,9 @@ abstract class HistoryDao : MangaQueryBuilder.ConditionCallback {
 	@Query("SELECT * FROM history WHERE manga_id = :id AND deleted_at = 0")
 	abstract suspend fun find(id: Long): HistoryEntity?
 
+	@Query("SELECT * FROM history WHERE manga_id = :id")
+	abstract suspend fun findRaw(id: Long): HistoryEntity?
+
 	@Query("SELECT * FROM history WHERE manga_id = :id AND deleted_at = 0")
 	abstract fun observe(id: Long): Flow<HistoryEntity?>
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/MainActivity.kt
@@ -9,8 +9,10 @@ import android.widget.LinearLayout
 import androidx.activity.viewModels
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.PopupMenu
+import androidx.core.graphics.Insets
 import androidx.core.view.GravityCompat
 import androidx.core.view.MenuProvider
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.core.view.inputmethod.EditorInfoCompat
@@ -104,6 +106,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 	private var isSearchFullyShown = false
 	private var mainFabModeKey: String? = null
 	private val shrinkFabRunnable = Runnable { viewBinding.fab?.shrink() }
+	private var navSystemBarBottom: Int = 0
 
 	override val appBar: AppBarLayout
 		get() = viewBinding.appbar
@@ -184,6 +187,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 		viewModel.isBottomNavPinned.observe(this, ::setNavbarPinned)
 		searchSuggestionViewModel.isIncognitoModeEnabled.observe(this, this::onIncognitoModeChanged)
 		viewBinding.bottomNav?.addOnLayoutChangeListener(this)
+		setupContainerInsetsListener()
 		viewBinding.searchView.addTransitionListener(this)
 		viewBinding.searchView.addTransitionListener(exitCallback)
 		observeFoldHinge()
@@ -278,6 +282,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 	override fun onApplyWindowInsets(v: View, insets: WindowInsetsCompat): WindowInsetsCompat {
 		val typeMask = WindowInsetsCompat.Type.systemBars()
 		val barsInsets = insets.getInsets(typeMask)
+		navSystemBarBottom = barsInsets.bottom
 		val searchBarDefaultMargin = resources.getDimensionPixelOffset(R.dimen.search_bar_margin_horizontal)
 		viewBinding.layoutSearch.updateLayoutParams<MarginLayoutParams> {
 			marginEnd = searchBarDefaultMargin + barsInsets.end(v)
@@ -316,6 +321,9 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 	) {
 		if (top != oldTop || bottom != oldBottom) {
 			updateContainerBottomMargin()
+			if (settings.isNavBarPinned && !settings.isLegacyNavigationBar) {
+				ViewCompat.requestApplyInsets(viewBinding.container)
+			}
 		}
 	}
 
@@ -555,14 +563,41 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), AppBarOwner, BottomNav
 			}
 		}
 		updateContainerBottomMargin()
+		// Re-dispatch window insets so child fragments update their RecyclerView bottom padding.
+		ViewCompat.requestApplyInsets(viewBinding.container)
+	}
+
+	private fun setupContainerInsetsListener() {
+		// When the nav bar is pinned, augment the bottom system-bar inset dispatched to child
+		// fragments by the pill's visual height. Fragment RecyclerViews apply this as bottom
+		// padding, so the last row can always be scrolled fully into view above the bar — without
+		// adding a container margin that would break the edge-to-edge look of the gesture area.
+		ViewCompat.setOnApplyWindowInsetsListener(viewBinding.container) { _, windowInsets ->
+			val extraBottom = if (settings.isNavBarPinned && !settings.isLegacyNavigationBar) {
+				((viewBinding.bottomNav?.height ?: 0) - navSystemBarBottom).coerceAtLeast(0)
+			} else {
+				0
+			}
+			if (extraBottom == 0) {
+				windowInsets
+			} else {
+				val type = WindowInsetsCompat.Type.systemBars()
+				val current = windowInsets.getInsets(type)
+				WindowInsetsCompat.Builder(windowInsets)
+					.setInsets(
+						type,
+						Insets.of(current.left, current.top, current.right, current.bottom + extraBottom),
+					)
+					.build()
+			}
+		}
 	}
 
 	private fun updateContainerBottomMargin() {
-		// The bottom navigation bar is a floating pill. Even when it's pinned (kept from hiding on
-		// scroll), the content must keep filling the full height *behind* it — otherwise the strip
-		// under the pill falls back to the solid window background and the bar stops looking
-		// floating. So the container never gets a bottom margin for the pinned bar; pinning only
-		// affects whether the bar/search hide on scroll.
+		// The bottom navigation bar is a floating pill. Content fills the full height *behind* it
+		// so the bar looks floating — the container never gets a bottom margin for the nav bar.
+		// Extra scrollable space when pinned is handled by augmenting window insets dispatched to
+		// child fragments (see the container insets listener set up in onCreate).
 		with(viewBinding.container) {
 			val params = layoutParams as MarginLayoutParams
 			if (params.bottomMargin != 0) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
@@ -13,6 +13,7 @@ import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaPage
 import org.koitharu.kotatsu.parsers.model.MangaState
 import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.util.longHashCode
 
 private const val TAG = "MihonDataConverters"
 
@@ -48,7 +49,7 @@ fun SManga.toManga(
 	val isContentNsfw = source.isNsfw || safeGenres?.any { it.lowercase() in adultGenres } == true
 
 	return Manga(
-		id = stableId(source.name, "manga", safeUrl),
+		id = stableId(source, "manga", safeUrl),
 		title = safeTitle,
 		altTitles = emptySet(),
 		url = safeUrl,
@@ -132,7 +133,7 @@ fun Manga.toSManga(): SManga {
 fun SChapter.toMangaChapter(source: MihonMangaSource, overrideNumber: Float? = null): MangaChapter {
 	val finalNumber = overrideNumber ?: (if (chapter_number >= 0f) chapter_number else 0f)
 	return MangaChapter(
-		id = stableId(source.name, "chapter", url),
+		id = stableId(source, "chapter", url),
 		title = name.takeIf { it.isNotBlank() },
 		number = finalNumber,
 		volume = 0,
@@ -155,7 +156,7 @@ fun MangaChapter.toSChapter(): SChapter = SChapter.create().apply {
 // ============ Page <-> MangaPage ============
 
 fun Page.toMangaPage(source: MihonMangaSource, chapterUrl: String): MangaPage = MangaPage(
-	id = stableId(source.name, "page", "$chapterUrl|$index"),
+	id = stableId(source, "page", "$chapterUrl|$index"),
 	url = imageUrl ?: url,
 	preview = imageUrl,
 	source = source,
@@ -163,8 +164,9 @@ fun Page.toMangaPage(source: MihonMangaSource, chapterUrl: String): MangaPage = 
 
 // ============ Internal Helpers ============
 
-private fun stableId(sourceName: String, type: String, value: String): Long {
-	return "$sourceName|$type|$value".hashCode().toLong() and Long.MAX_VALUE
+private fun stableId(source: MihonMangaSource, type: String, value: String): Long {
+	val sourceKey = "mihon:${source.pkgName}:${source.catalogueSource.name}"
+	return "$sourceKey|$type|$value".longHashCode()
 }
 
 private fun resolveUrl(baseUrl: String?, value: String?): String? {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/ChaptersLoader.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/ChaptersLoader.kt
@@ -3,8 +3,6 @@ package org.koitharu.kotatsu.reader.domain
 import android.util.LongSparseArray
 import androidx.annotation.CheckResult
 import dagger.hilt.android.scopes.ViewModelScoped
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koitharu.kotatsu.core.parser.MangaRepository
 import org.koitharu.kotatsu.details.data.MangaDetails
 import org.koitharu.kotatsu.parsers.model.MangaChapter
@@ -21,12 +19,11 @@ class ChaptersLoader @Inject constructor(
 
 	private val chapters = LongSparseArray<MangaChapter>()
 	private val chapterPages = ChapterPages()
-	private val mutex = Mutex()
 
 	val size: Int
-		get() = chapters.size()
+		get() = synchronized(chapterPages) { chapters.size() }
 
-	suspend fun init(manga: MangaDetails) = mutex.withLock {
+	fun init(manga: MangaDetails) = synchronized(chapterPages) {
 		chapters.clear()
 		manga.allChapters.forEach {
 			chapters.put(it.id, it)
@@ -40,7 +37,7 @@ class ChaptersLoader @Inject constructor(
 		if (index == -1) return false
 		val newChapter = chapters.getOrNull(if (isNext) index + 1 else index - 1) ?: return false
 		val newPages = loadChapter(newChapter.id)
-		mutex.withLock {
+		synchronized(chapterPages) {
 			if (chapterPages.chaptersSize > 1) {
 				// trim pages
 				if (chapterPages.size > PAGES_TRIM_THRESHOLD) {
@@ -63,32 +60,40 @@ class ChaptersLoader @Inject constructor(
 	@CheckResult
 	suspend fun loadSingleChapter(chapterId: Long): Boolean {
 		val pages = loadChapter(chapterId)
-		return mutex.withLock {
+		return synchronized(chapterPages) {
 			chapterPages.clear()
 			chapterPages.addLast(chapterId, pages)
 			pages.isNotEmpty()
 		}
 	}
 
-	fun peekChapter(chapterId: Long): MangaChapter? = chapters[chapterId]
+	fun peekChapter(chapterId: Long): MangaChapter? = synchronized(chapterPages) {
+		chapters[chapterId]
+	}
 
-	fun hasPages(chapterId: Long): Boolean {
-		return chapterId in chapterPages
+	fun hasPages(chapterId: Long): Boolean = synchronized(chapterPages) {
+		chapterId in chapterPages
 	}
 
 	fun getPages(chapterId: Long): List<MangaPage> = synchronized(chapterPages) {
 		return chapterPages.subList(chapterId).map { it.toMangaPage() }
 	}
 
-	fun getPagesCount(chapterId: Long): Int {
+	fun getPagesCount(chapterId: Long): Int = synchronized(chapterPages) {
 		return chapterPages.size(chapterId)
 	}
 
-	fun last() = chapterPages.last()
+	fun last() = synchronized(chapterPages) {
+		chapterPages.last()
+	}
 
-	fun first() = chapterPages.first()
+	fun first() = synchronized(chapterPages) {
+		chapterPages.first()
+	}
 
-	fun snapshot() = chapterPages.toList()
+	fun snapshot(): List<ReaderPage> = synchronized(chapterPages) {
+		chapterPages.toList()
+	}
 
 	private suspend fun loadChapter(chapterId: Long): List<ReaderPage> {
 		val chapter = checkNotNull(chapters[chapterId]) { "Requested chapter not found" }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
@@ -97,7 +97,9 @@ class PageLoader @Inject constructor(
 
 	private val tasks = LongSparseArray<ProgressDeferred<Uri, Float>>()
 	private val semaphore = Semaphore(3)
-	private val convertLock = Mutex()
+	private val convertSemaphore = Semaphore(
+		(Runtime.getRuntime().maxMemory() / (1024 * 1024 * 128)).toInt().coerceIn(1, 4)
+	)
 	private val prefetchLock = Mutex()
 
 	@Volatile
@@ -118,7 +120,10 @@ class PageLoader @Inject constructor(
 	fun prefetch(pages: List<ReaderPage>) = loaderScope.launch {
 		prefetchLock.withLock {
 			for (page in pages.asReversed()) {
-				if (tasks.containsKey(page.id)) {
+				val exists = synchronized(tasks) {
+					tasks.containsKey(page.id)
+				}
+				if (exists) {
 					continue
 				}
 				prefetchQueue.offerFirst(page.toMangaPage())
@@ -146,17 +151,17 @@ class PageLoader @Inject constructor(
 	}
 
 	fun loadPageAsync(page: MangaPage, force: Boolean): ProgressDeferred<Uri, Float> {
-		var task = tasks[page.id]?.takeIf { it.isValid() }
-		if (force) {
-			task?.cancel()
-		} else if (task?.isCancelled == false) {
-			return task
-		}
-		task = loadPageAsyncImpl(page, skipCache = force, isPrefetch = false)
-		synchronized(tasks) {
+		return synchronized(tasks) {
+			var task = tasks[page.id]?.takeIf { it.isValid() }
+			if (force) {
+				task?.cancel()
+			} else if (task?.isCancelled == false) {
+				return@synchronized task
+			}
+			task = loadPageAsyncImpl(page, skipCache = force, isPrefetch = false)
 			tasks[page.id] = task
+			task
 		}
-		return task
 	}
 
 	suspend fun loadPage(page: MangaPage, force: Boolean): Uri {
@@ -164,7 +169,7 @@ class PageLoader @Inject constructor(
 	}
 
 	@CheckResult
-	suspend fun convertBimap(uri: Uri): Uri = convertLock.withLock {
+	suspend fun convertBimap(uri: Uri): Uri = convertSemaphore.withPermit {
 		if (uri.isZipUri()) {
 			runInterruptible(Dispatchers.IO) {
 				ZipFile(uri.schemeSpecificPart).use { zip ->
@@ -200,8 +205,20 @@ class PageLoader @Inject constructor(
 	}
 
 	suspend fun invalidate(clearCache: Boolean) {
-		tasks.clear()
+		val tasksToCancel = synchronized(tasks) {
+			val list = ArrayList<ProgressDeferred<Uri, Float>>(tasks.size())
+			for (i in 0 until tasks.size()) {
+				list.add(tasks.valueAt(i))
+			}
+			list
+		}
+		for (task in tasksToCancel) {
+			task.cancel()
+		}
 		loaderScope.cancelChildrenAndJoin()
+		synchronized(tasks) {
+			tasks.clear()
+		}
 		if (clearCache) {
 			cache.clear()
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/PageSaveHelper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/PageSaveHelper.kt
@@ -201,7 +201,7 @@ class PageSaveHelper @AssistedInject constructor(
 			append('-')
 			append(pageNumber)
 			append('_')
-			append(SimpleDateFormat("yyyy-MM-dd_HHmm").format(Date()))
+			append(SimpleDateFormat("yyyy-MM-dd_HHmm", java.util.Locale.ROOT).format(Date()))
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.bookmarks.domain.Bookmark
 import org.koitharu.kotatsu.bookmarks.domain.BookmarksRepository
@@ -106,6 +108,7 @@ class ReaderViewModel @Inject constructor(
 ) {
     private val intent = MangaIntent(savedStateHandle)
 
+    private val loadingMutex = Mutex()
     private var loadingJob: Job? = null
     private var pageSaveJob: Job? = null
     private var bookmarkJob: Job? = null
@@ -289,50 +292,52 @@ class ReaderViewModel @Inject constructor(
         val state = readingState.value ?: return null
         return content.value.pages.find {
             it.chapterId == state.chapterId && it.index == state.page
-        }?.toMangaPage()
+        }?.toMangaPage() ?: chaptersLoader.getPages(state.chapterId).getOrNull(state.page)
     }
 
     fun switchChapter(id: Long, page: Int) {
-        val prevJob = loadingJob
+        loadingJob?.cancel()
         loadingJob = launchLoadingJob(Dispatchers.Default) {
-            prevJob?.cancelAndJoin()
-            content.value = ReaderContent(emptyList(), null)
-            if (!chaptersLoader.loadSingleChapter(id)) {
-                return@launchLoadingJob
+            loadingMutex.withLock {
+                content.value = ReaderContent(emptyList(), null)
+                if (!chaptersLoader.loadSingleChapter(id)) {
+                    return@withLock
+                }
+                val newState = ReaderState(id, page, 0)
+                content.value = ReaderContent(chaptersLoader.snapshot(), newState)
+                saveCurrentState(newState)
             }
-            val newState = ReaderState(id, page, 0)
-            content.value = ReaderContent(chaptersLoader.snapshot(), newState)
-            saveCurrentState(newState)
         }
     }
 
     fun switchChapterBy(delta: Int) {
-        val prevJob = loadingJob
+        loadingJob?.cancel()
         loadingJob = launchLoadingJob(Dispatchers.Default) {
-            prevJob?.cancelAndJoin()
-            val prevState = readingState.requireValue()
-            val newChapterId = if (delta != 0) {
-                val allChapters = mangaDetails.requireValue().allChapters
-                var index = allChapters.indexOfFirst { x -> x.id == prevState.chapterId }
-                if (index < 0) {
-                    return@launchLoadingJob
+            loadingMutex.withLock {
+                val prevState = readingState.requireValue()
+                val newChapterId = if (delta != 0) {
+                    val allChapters = mangaDetails.requireValue().allChapters
+                    var index = allChapters.indexOfFirst { x -> x.id == prevState.chapterId }
+                    if (index < 0) {
+                        return@withLock
+                    }
+                    index += delta
+                    (allChapters.getOrNull(index) ?: return@withLock).id
+                } else {
+                    prevState.chapterId
                 }
-                index += delta
-                (allChapters.getOrNull(index) ?: return@launchLoadingJob).id
-            } else {
-                prevState.chapterId
+                content.value = ReaderContent(emptyList(), null)
+                if (!chaptersLoader.loadSingleChapter(newChapterId)) {
+                    return@withLock
+                }
+                val newState = ReaderState(
+                    chapterId = newChapterId,
+                    page = if (delta == 0) prevState.page else 0,
+                    scroll = if (delta == 0) prevState.scroll else 0,
+                )
+                content.value = ReaderContent(chaptersLoader.snapshot(), newState)
+                saveCurrentState(newState)
             }
-            content.value = ReaderContent(emptyList(), null)
-            if (!chaptersLoader.loadSingleChapter(newChapterId)) {
-                return@launchLoadingJob
-            }
-            val newState = ReaderState(
-                chapterId = newChapterId,
-                page = if (delta == 0) prevState.page else 0,
-                scroll = if (delta == 0) prevState.scroll else 0,
-            )
-            content.value = ReaderContent(chaptersLoader.snapshot(), newState)
-            saveCurrentState(newState)
         }
     }
 
@@ -342,9 +347,9 @@ class ReaderViewModel @Inject constructor(
         val pages = content.value.pages // capture immediately
         stateChangeJob = launchJob(Dispatchers.Default) {
             prevJob?.cancelAndJoin()
-            loadingJob?.join()
-            if (pages.size != content.value.pages.size) {
-                return@launchJob // TODO
+            loadingMutex.withLock { }
+            if (pages !== content.value.pages) {
+                return@launchJob
             }
             val centerPos = (lowerPos + upperPos) / 2
             pages.getOrNull(centerPos)?.let { page ->
@@ -353,7 +358,7 @@ class ReaderViewModel @Inject constructor(
                 }
             }
             notifyStateChanged()
-            if (pages.isEmpty() || loadingJob?.isActive == true) {
+            if (pages.isEmpty() || loadingMutex.isLocked) {
                 return@launchJob
             }
             ensureActive()
@@ -377,7 +382,7 @@ class ReaderViewModel @Inject constructor(
             return
         }
         bookmarkJob = launchJob(Dispatchers.Default) {
-            loadingJob?.join()
+            loadingMutex.withLock { }
             val state = checkNotNull(getCurrentState())
             if (isBookmarkAdded.value) {
                 val manga = requireManga()
@@ -494,11 +499,14 @@ class ReaderViewModel @Inject constructor(
 
     @AnyThread
     private fun loadPrevNextChapter(currentId: Long, isNext: Boolean) {
-        val prevJob = loadingJob
         loadingJob = launchLoadingJob(Dispatchers.Default) {
-            prevJob?.join()
-            chaptersLoader.loadPrevNextChapter(mangaDetails.requireValue(), currentId, isNext)
-            content.value = ReaderContent(chaptersLoader.snapshot(), null)
+            // Serialize against switchChapter/switchChapterBy via the same mutex (wait for any
+            // in-flight load to finish rather than cancelling it) so chaptersLoader/content stay
+            // consistent.
+            loadingMutex.withLock {
+                chaptersLoader.loadPrevNextChapter(mangaDetails.requireValue(), currentId, isNext)
+                content.value = ReaderContent(chaptersLoader.snapshot(), null)
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
@@ -142,7 +142,11 @@ abstract class BasePageHolder<B : ViewBinding>(
 	}
 
 	override fun onTrimMemory(level: Int) {
-		// TODO
+		if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND ||
+			level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+		) {
+			ssiv.recycle()
+		}
 	}
 
 	override fun onConfigurationChanged(newConfig: Configuration) = Unit

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/doublepage/DoublePageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/doublepage/DoublePageHolder.kt
@@ -54,16 +54,20 @@ class DoublePageHolder(
 	}
 
 	override fun onReady() {
+		val sWidth = binding.ssiv.sWidth.toFloat()
+		val sHeight = binding.ssiv.sHeight.toFloat()
+		if (sWidth <= 0f || sHeight <= 0f) return
+
 		with(binding.ssiv) {
 			maxScale = 2f * maxOf(
-				width / sWidth.toFloat(),
-				height / sHeight.toFloat(),
+				width / sWidth,
+				height / sHeight,
 			)
 			binding.ssiv.colorFilter = settings.colorFilter?.toColorFilter()
 			minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
 			setScaleAndCenter(
 				minScale,
-				PointF(if (isEven) 0f else sWidth.toFloat(), sHeight / 2f),
+				PointF(if (isEven) 0f else sWidth, sHeight / 2f),
 			)
 		}
 		alignPageToCenterSeam()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/doublereversed/ReversedDoubleReaderFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/doublereversed/ReversedDoubleReaderFragment.kt
@@ -23,6 +23,7 @@ class ReversedDoubleReaderFragment : DoubleReaderFragment() {
 	}
 
 	private fun reversed(position: Int): Int {
-		return ((readerAdapter?.itemCount ?: 0) - position - 1).coerceAtLeast(0)
+		val size = viewModel.content.value.pages.size
+		return (size - position - 1).coerceAtLeast(0)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/reversed/ReversedPageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/reversed/ReversedPageHolder.kt
@@ -35,10 +35,14 @@ class ReversedPageHolder(
 	}
 
 	override fun onReady() {
+		val sWidth = binding.ssiv.sWidth.toFloat()
+		val sHeight = binding.ssiv.sHeight.toFloat()
+		if (sWidth <= 0f || sHeight <= 0f) return
+
 		with(binding.ssiv) {
 			maxScale = 2f * maxOf(
-				width / sWidth.toFloat(),
-				height / sHeight.toFloat(),
+				width / sWidth,
+				height / sHeight,
 			)
 			binding.ssiv.colorFilter = settings.colorFilter?.toColorFilter()
 			when (settings.zoomMode) {
@@ -49,16 +53,16 @@ class ReversedPageHolder(
 
 				ZoomMode.FIT_HEIGHT -> {
 					minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CUSTOM
-					minScale = height / sHeight.toFloat()
+					minScale = height / sHeight
 					setScaleAndCenter(
 						minScale,
-						PointF(sWidth.toFloat(), sHeight / 2f),
+						PointF(sWidth, sHeight / 2f),
 					)
 				}
 
 				ZoomMode.FIT_WIDTH -> {
 					minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CUSTOM
-					minScale = width / sWidth.toFloat()
+					minScale = width / sWidth
 					setScaleAndCenter(
 						minScale,
 						PointF(sWidth / 2f, 0f),
@@ -69,7 +73,7 @@ class ReversedPageHolder(
 					minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
 					setScaleAndCenter(
 						maxScale,
-						PointF(sWidth.toFloat(), 0f),
+						PointF(sWidth, 0f),
 					)
 				}
 			}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/reversed/ReversedReaderFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/reversed/ReversedReaderFragment.kt
@@ -47,6 +47,7 @@ class ReversedReaderFragment : BasePagerReaderFragment() {
 	}
 
 	private fun reversed(position: Int): Int {
-		return ((readerAdapter?.itemCount ?: 0) - position - 1).coerceAtLeast(0)
+		val size = viewModel.content.value.pages.size
+		return (size - position - 1).coerceAtLeast(0)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/standard/PageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/standard/PageHolder.kt
@@ -75,9 +75,13 @@ open class PageHolder(
 	}
 
 	override fun onReady() {
+		val sWidth = binding.ssiv.sWidth.toFloat()
+		val sHeight = binding.ssiv.sHeight.toFloat()
+		if (sWidth <= 0f || sHeight <= 0f) return
+
 		binding.ssiv.maxScale = 2f * maxOf(
-			binding.ssiv.width / binding.ssiv.sWidth.toFloat(),
-			binding.ssiv.height / binding.ssiv.sHeight.toFloat(),
+			binding.ssiv.width / sWidth,
+			binding.ssiv.height / sHeight,
 		)
 		binding.ssiv.colorFilter = settings.colorFilter?.toColorFilter()
 		when (settings.zoomMode) {
@@ -88,19 +92,19 @@ open class PageHolder(
 
 			ZoomMode.FIT_HEIGHT -> {
 				binding.ssiv.minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CUSTOM
-				binding.ssiv.minScale = binding.ssiv.height / binding.ssiv.sHeight.toFloat()
+				binding.ssiv.minScale = binding.ssiv.height / sHeight
 				binding.ssiv.setScaleAndCenter(
 					binding.ssiv.minScale,
-					PointF(0f, binding.ssiv.sHeight / 2f),
+					PointF(0f, sHeight / 2f),
 				)
 			}
 
 			ZoomMode.FIT_WIDTH -> {
 				binding.ssiv.minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_CUSTOM
-				binding.ssiv.minScale = binding.ssiv.width / binding.ssiv.sWidth.toFloat()
+				binding.ssiv.minScale = binding.ssiv.width / sWidth
 				binding.ssiv.setScaleAndCenter(
 					binding.ssiv.minScale,
-					PointF(binding.ssiv.sWidth / 2f, 0f),
+					PointF(sWidth / 2f, 0f),
 				)
 			}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/vm/PageViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/vm/PageViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +37,7 @@ class PageViewModel(
 	private val isWebtoon: Boolean,
 ) : DefaultOnImageEventListener {
 
-	private val scope = loader.loaderScope + Dispatchers.Main.immediate
+	private var currentScope: CoroutineScope? = null
 	private var job: Job? = null
 	private var cachedBounds: Rect? = null
 
@@ -45,6 +46,14 @@ class PageViewModel(
 	fun isLoading() = job?.isActive == true
 
 	fun onBind(page: MangaPage) {
+		currentScope?.cancel()
+		// Parent the per-holder Job to loaderScope's Job so it is also cancelled on reader teardown,
+		// not only on onRecycle(). A bare Job() would be a detached root and leak if a holder is
+		// never recycled before the reader closes.
+		val scope = CoroutineScope(
+			loader.loaderScope.coroutineContext + Job(loader.loaderScope.coroutineContext[Job]) + Dispatchers.Main.immediate,
+		)
+		currentScope = scope
 		val prevJob = job
 		job = scope.launch(Dispatchers.Default) {
 			prevJob?.cancelAndJoin()
@@ -53,6 +62,7 @@ class PageViewModel(
 	}
 
 	fun retry(page: MangaPage, isFromUser: Boolean) {
+		val scope = currentScope ?: return
 		val prevJob = job
 		job = scope.launch {
 			prevJob?.cancelAndJoin()
@@ -74,9 +84,11 @@ class PageViewModel(
 	}
 
 	fun onRecycle() {
+		currentScope?.cancel()
+		currentScope = null
 		state.value = PageState.Empty
 		cachedBounds = null
-		job?.cancel()
+		job = null
 	}
 
 	override fun onImageLoaded() {
@@ -108,6 +120,7 @@ class PageViewModel(
 	}
 
 	private fun tryConvert(uri: Uri, e: Exception) {
+		val scope = currentScope ?: return
 		val prevJob = job
 		job = scope.launch(Dispatchers.Default) {
 			prevJob?.join()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/anilist/data/AniListRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/anilist/data/AniListRepository.kt
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
+import org.koitharu.kotatsu.BuildConfig
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.db.MangaDatabase
 import org.koitharu.kotatsu.parsers.exception.GraphQLException
@@ -46,8 +47,8 @@ class AniListRepository @Inject constructor(
 	private val db: MangaDatabase,
 ) : ScrobblerRepository {
 
-	private val clientId = context.getString(R.string.anilist_clientId)
-	private val clientSecret = context.getString(R.string.anilist_clientSecret)
+	private val clientId = BuildConfig.ANILIST_CLIENT_ID
+	private val clientSecret = BuildConfig.ANILIST_CLIENT_SECRET
 
 	override val oauthUrl: String
 		get() = "${BASE_URL}oauth/authorize?client_id=$clientId&" +

--- a/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/common/data/ScrobblingEntity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/common/data/ScrobblingEntity.kt
@@ -16,12 +16,14 @@ class ScrobblingEntity(
 	@ColumnInfo(name = "chapter") val chapter: Int,
 	@ColumnInfo(name = "comment") val comment: String?,
 	@ColumnInfo(name = "rating") val rating: Float,
+	@ColumnInfo(name = "updated_at", defaultValue = "0") val updatedAt: Long = System.currentTimeMillis(),
 ) {
 
 	fun copy(
 		status: String?,
 		comment: String?,
 		rating: Float,
+		updatedAt: Long = System.currentTimeMillis(),
 	) = ScrobblingEntity(
 		scrobbler = scrobbler,
 		id = id,
@@ -31,5 +33,6 @@ class ScrobblingEntity(
 		chapter = chapter,
 		comment = comment,
 		rating = rating,
+		updatedAt = updatedAt,
 	)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/shikimori/data/ShikimoriRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/scrobbling/shikimori/data/ShikimoriRepository.kt
@@ -7,6 +7,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import org.koitharu.kotatsu.BuildConfig
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.db.MangaDatabase
 import org.koitharu.kotatsu.core.util.ext.toRequestBody
@@ -40,8 +41,8 @@ class ShikimoriRepository @Inject constructor(
 	private val db: MangaDatabase,
 ) : ScrobblerRepository {
 
-	private val clientId = context.getString(R.string.shikimori_clientId)
-	private val clientSecret = context.getString(R.string.shikimori_clientSecret)
+	private val clientId = BuildConfig.SHIKIMORI_CLIENT_ID
+	private val clientSecret = BuildConfig.SHIKIMORI_CLIENT_SECRET
 
 	override val oauthUrl: String
 		get() = "${BASE_URL}oauth/authorize?client_id=$clientId&" +

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
@@ -505,7 +505,7 @@ private fun AppearanceScreen(
 						title = stringResource(R.string.show_labels_in_navbar),
 						checked = navLabels,
 						onCheckedChange = { navLabels = it },
-						icon = R.drawable.ic_script,
+						icon = R.drawable.ic_title,
 						
 						shape = pos.shape,
 					)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
@@ -495,8 +495,8 @@ private fun AppearanceScreen(
 						subtitle = stringResource(R.string.main_screen_fab_summary),
 						checked = mainFab,
 						onCheckedChange = { mainFab = it },
-						icon = R.drawable.ic_add,
-						
+						icon = R.drawable.ic_read,
+
 						shape = pos.shape,
 					)
 				}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/NotificationSettingsLegacyFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/NotificationSettingsLegacyFragment.kt
@@ -115,7 +115,7 @@ private fun NotificationsScreen(
 						title = stringResource(R.string.vibration),
 						checked = vibrate,
 						onCheckedChange = { vibrate = it },
-						icon = R.drawable.ic_timelapse,
+						icon = R.drawable.ic_haptic,
 						shape = pos.shape,
 						enabled = enabled,
 					)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/ProxySettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/ProxySettingsFragment.kt
@@ -142,7 +142,7 @@ private fun ProxyScreen(
 						entryValues = proxyTypeValues,
 						selectedValue = proxyType,
 						onValueChange = { proxyType = it },
-						icon = R.drawable.ic_sync,
+						icon = R.drawable.ic_settings,
 						shape = pos.shape,
 					)
 				}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
@@ -299,7 +299,7 @@ private fun ReaderScreen(
 						entryValues = readerAnimationValues,
 						selectedValue = readerAnimation,
 						onValueChange = { readerAnimation = it },
-						icon = R.drawable.ic_timelapse,
+						icon = R.drawable.ic_play,
 						
 						shape = pos.shape,
 					)
@@ -465,7 +465,7 @@ private fun ReaderScreen(
 						subtitle = stringResource(R.string.show_pages_numbers_summary),
 						checked = pagesNumbers,
 						onCheckedChange = { pagesNumbers = it },
-						icon = R.drawable.ic_tag,
+						icon = R.drawable.ic_title,
 						
 						shape = pos.shape,
 					)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
@@ -112,6 +112,7 @@ class SettingsActivity :
 	}
 
 	fun openFragment(fragmentClass: Class<out Fragment>, args: Bundle?, isFromRoot: Boolean) {
+		org.koitharu.kotatsu.settings.compose.SettingsSearchHighlight.clear()
 		viewModel.discardSearch()
 		val fm = supportFragmentManager
 		val current = fm.findFragmentById(R.id.container)
@@ -201,9 +202,9 @@ class SettingsActivity :
 		val args = buildBundle(1) {
 			putString(ARG_PREF_KEY, item.key)
 		}
-		openFragment(item.fragmentClass, args, true)
-		// Ask the target Compose screen to flash the matching row once (matched by title).
-		org.koitharu.kotatsu.settings.compose.SettingsSearchHighlight.request(item.title.toString())
+		openFragment(item.fragmentClass, args, false)
+		// Ask the target Compose screen to flash the matching row once.
+		org.koitharu.kotatsu.settings.compose.SettingsSearchHighlight.request(item.key, item.title.toString())
 	}
 
 	private fun observeFoldHinge() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/StorageAndNetworkSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/StorageAndNetworkSettingsFragment.kt
@@ -219,7 +219,7 @@ private fun StorageNetworkScreen(
 					NavigationSettingsItem(
 						title = stringResource(R.string.proxy),
 						subtitle = proxySummary,
-						icon = R.drawable.ic_sync,
+						icon = R.drawable.ic_plug_large,
 						
 						shape = pos.shape,
 						onClick = onOpenProxy,
@@ -255,7 +255,7 @@ private fun StorageNetworkScreen(
 						entryValues = imageProxyValues,
 						selectedValue = imageProxy,
 						onValueChange = { imageProxy = it },
-						icon = R.drawable.ic_filter_menu,
+						icon = R.drawable.ic_images,
 						
 						shape = pos.shape,
 					)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/changelog/ChangelogViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/changelog/ChangelogViewModel.kt
@@ -23,9 +23,13 @@ class ChangelogViewModel @Inject constructor(
 				stringJoiner.add("# ")
 					.append(version.name)
 					.append("\n\n")
-					.append(version.description)
+					.append(version.description.formatChangelogDescription())
 			}
 			changelog.value = stringJoiner.complete()
 		}
+	}
+
+	private fun String.formatChangelogDescription(): String {
+		return replace(Regex("(?<!\\n)\\nIf this is your first"), "\n\nIf this is your first")
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsHighlight.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsHighlight.kt
@@ -4,24 +4,34 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Tiny process-wide bus that lets the settings-search flow ask a freshly-opened Compose screen
- * to highlight a specific row once. Rows are matched by their (localized) title — every
- * [SettingsItem] already has one, so no per-row wiring is needed.
+ * to highlight a specific row once. Rows are matched by their preference key or (localized) title.
  *
- * [SettingsActivity] sets [pendingTitle] right after navigating to a search result; the matching
+ * [SettingsActivity] sets [pendingKey]/[pendingTitle] right after navigating to a search result; the matching
  * [SettingsItem] flashes its background a single time and then calls [consume] to clear it, so the
  * highlight never repeats on recomposition or re-entry.
  */
 object SettingsSearchHighlight {
 
+	val pendingKey = MutableStateFlow<String?>(null)
 	val pendingTitle = MutableStateFlow<String?>(null)
 
-	fun request(title: String?) {
+	fun request(key: String?, title: String?) {
+		pendingKey.value = key?.takeIf { it.isNotBlank() }
 		pendingTitle.value = title?.takeIf { it.isNotBlank() }
 	}
 
-	fun consume(title: String) {
-		if (pendingTitle.value == title) {
+	fun consume(key: String?, title: String) {
+		if (key != null && pendingKey.value == key) {
+			pendingKey.value = null
+			pendingTitle.value = null
+		} else if (pendingTitle.value == title) {
+			pendingKey.value = null
 			pendingTitle.value = null
 		}
+	}
+
+	fun clear() {
+		pendingKey.value = null
+		pendingTitle.value = null
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsItem.kt
@@ -64,12 +64,17 @@ fun SettingsItem(
 	onClick: (() -> Unit)? = null,
 	hapticEffect: HapticEffect? = null,
 	trailing: @Composable (() -> Unit)? = null,
+	key: String? = null,
 ) {
 	val haptic = rememberHapticEffect()
 	// One-shot search highlight: scroll this row comfortably into view and flash its background
-	// once when it is the navigation target (matched by title).
-	val pendingHighlight by SettingsSearchHighlight.pendingTitle.collectAsState()
-	val isHighlightTarget = pendingHighlight != null && pendingHighlight == title
+	// once when it is the navigation target (matched by key or title fallback).
+	val pendingKey by SettingsSearchHighlight.pendingKey.collectAsState()
+	val pendingTitle by SettingsSearchHighlight.pendingTitle.collectAsState()
+	val isHighlightTarget = when {
+		key != null -> pendingKey != null && pendingKey == key
+		else -> pendingTitle != null && pendingTitle == title
+	}
 	val scrollToHighlight = LocalSettingsHighlightScroll.current
 	val rowWindowY = remember { mutableFloatStateOf(Float.NaN) }
 	val highlight = remember { Animatable(0f) }
@@ -81,7 +86,7 @@ fun SettingsItem(
 			highlight.snapTo(1f)
 			delay(320)
 			highlight.animateTo(0f, animationSpec = tween(durationMillis = 1100))
-			SettingsSearchHighlight.consume(title)
+			SettingsSearchHighlight.consume(key, title)
 		}
 	}
 	val containerColor = lerp(
@@ -170,6 +175,7 @@ fun SwitchSettingsItem(
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
+	key: String? = null,
 ) {
 	val haptic = rememberHapticEffect()
 	val onCheckedChangeHaptic: (Boolean) -> Unit = { value ->
@@ -193,6 +199,7 @@ fun SwitchSettingsItem(
 		trailing = {
 			Switch(checked = checked, onCheckedChange = onCheckedChangeHaptic, enabled = enabled)
 		},
+		key = key,
 	)
 }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsPreferenceItems.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/SettingsPreferenceItems.kt
@@ -40,6 +40,7 @@ fun ListSettingsItem(
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
+	key: String? = null,
 ) {
 	var showDialog by remember { mutableStateOf(false) }
 	val selectedIndex = entryValues.indexOf(selectedValue).coerceAtLeast(0)
@@ -54,6 +55,7 @@ fun ListSettingsItem(
 		shape = shape,
 		enabled = enabled,
 		onClick = { showDialog = true },
+		key = key,
 	)
 
 	if (showDialog) {
@@ -80,6 +82,7 @@ fun MultiSelectSettingsItem(
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
+	key: String? = null,
 ) {
 	var showDialog by remember { mutableStateOf(false) }
 	val selectedIndices = entryValues
@@ -96,6 +99,7 @@ fun MultiSelectSettingsItem(
 		shape = shape,
 		enabled = enabled,
 		onClick = { showDialog = true },
+		key = key,
 	)
 
 	if (showDialog) {
@@ -124,6 +128,7 @@ fun EditTextSettingsItem(
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
 	mask: ((String) -> String)? = null,
+	key: String? = null,
 ) {
 	var showDialog by remember { mutableStateOf(false) }
 	val displayValue = remember(value, mask) { mask?.invoke(value) ?: value }
@@ -137,6 +142,7 @@ fun EditTextSettingsItem(
 		shape = shape,
 		enabled = enabled,
 		onClick = { showDialog = true },
+		key = key,
 	)
 
 	if (showDialog) {
@@ -195,6 +201,7 @@ fun NavigationSettingsItem(
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
+	key: String? = null,
 ) {
 	SettingsItem(
 		title = title,
@@ -205,6 +212,7 @@ fun NavigationSettingsItem(
 		shape = shape,
 		enabled = enabled,
 		onClick = onClick,
+		key = key,
 	)
 }
 
@@ -220,6 +228,7 @@ fun ActionSettingsItem(
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
 	enabled: Boolean = true,
+	key: String? = null,
 ) {
 	SettingsItem(
 		title = title,
@@ -230,6 +239,7 @@ fun ActionSettingsItem(
 		shape = shape,
 		enabled = enabled,
 		onClick = onClick,
+		key = key,
 	)
 }
 
@@ -242,6 +252,7 @@ fun InfoSettingsItem(
 	@DrawableRes icon: Int? = null,
 	iconColors: CategoryIconColors? = null,
 	shape: Shape = MaterialTheme.shapes.medium,
+	key: String? = null,
 ) {
 	SettingsItem(
 		title = title,
@@ -252,6 +263,7 @@ fun InfoSettingsItem(
 		shape = shape,
 		enabled = true,
 		onClick = null,
+		key = key,
 	)
 }
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchHelper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchHelper.kt
@@ -15,11 +15,14 @@ import org.koitharu.kotatsu.settings.ReaderSettingsFragment
 import org.koitharu.kotatsu.settings.ServicesSettingsFragment
 import org.koitharu.kotatsu.settings.StorageAndNetworkSettingsFragment
 import org.koitharu.kotatsu.settings.SuggestionsSettingsFragment
+import org.koitharu.kotatsu.settings.NotificationSettingsLegacyFragment
 import org.koitharu.kotatsu.settings.about.AboutSettingsFragment
+import org.koitharu.kotatsu.settings.appearance.PreviewSettingsFragment
 import org.koitharu.kotatsu.settings.discord.DiscordSettingsFragment
 import org.koitharu.kotatsu.settings.sources.ExtensionsSettingsFragment
 import org.koitharu.kotatsu.settings.tracker.TrackerSettingsFragment
 import org.koitharu.kotatsu.settings.userdata.storage.DataCleanupSettingsFragment
+import org.koitharu.kotatsu.sync.ui.SyncSettingsFragment
 import javax.inject.Inject
 
 @Reusable
@@ -38,10 +41,14 @@ class SettingsSearchHelper @Inject constructor(
 			summaryRes: Int? = null,
 			breadcrumbs: List<String>,
 			fragmentClass: Class<out Fragment>,
+			keywordRes: IntArray = IntArray(0),
+			keywordArrayRes: IntArray = IntArray(0),
+			keywordText: List<String> = emptyList(),
 		) {
 			val title = ctx.getString(titleRes)
 			val summary = summaryRes?.let(ctx::getString).orEmpty()
-			val searchText = buildSearchText(title, key, summary, breadcrumbs)
+			val keywords = keywordRes.map(ctx::getString) + keywordArrayRes.flatMap { ctx.resources.getStringArray(it).asList() } + keywordText
+			val searchText = buildSearchText(title, key, summary, breadcrumbs, keywords)
 			result.add(
 				SettingsItem(
 					key = key,
@@ -69,22 +76,24 @@ class SettingsSearchHelper @Inject constructor(
 		section(R.string.appearance, AppearanceSettingsFragment::class.java) { sectionCrumbs ->
 			group(sectionCrumbs, "Theme") { crumbs ->
 				addItem(AppSettings.KEY_COLOR_THEME, R.string.color_theme, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
-				addItem(AppSettings.KEY_THEME, R.string.theme, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_THEME, R.string.theme, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.themes))
 				addItem(AppSettings.KEY_THEME_AMOLED, R.string.black_dark_theme, R.string.black_dark_theme_summary, crumbs, AppearanceSettingsFragment::class.java)
 				addItem(AppSettings.KEY_APP_LOCALE, R.string.language, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, ctx.getString(R.string.manga_list)) { crumbs ->
-				addItem(AppSettings.KEY_LIST_MODE, R.string.list_mode, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_LIST_MODE, R.string.list_mode, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.list_modes))
 				addItem(AppSettings.KEY_GRID_SIZE, R.string.grid_size, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
 				addItem(AppSettings.KEY_QUICK_FILTER, R.string.show_quick_filters, R.string.show_quick_filters_summary, crumbs, AppearanceSettingsFragment::class.java)
 				addItem(AppSettings.KEY_PROGRESS_INDICATORS, R.string.show_reading_indicators, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
-				addItem(AppSettings.KEY_MANGA_LIST_BADGES, R.string.badges_in_lists, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_MANGA_LIST_BADGES, R.string.badges_in_lists, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.list_badges))
 			}
 			group(sectionCrumbs, ctx.getString(R.string.details)) { crumbs ->
 				addItem(AppSettings.KEY_COLLAPSE_DESCRIPTION, R.string.collapse_long_description, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
 				addItem(AppSettings.KEY_PAGES_TAB, R.string.show_pages_thumbs, R.string.show_pages_thumbs_summary, crumbs, AppearanceSettingsFragment::class.java)
-				addItem(AppSettings.KEY_DETAILS_TAB, R.string.default_tab, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_DETAILS_TAB, R.string.default_tab, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.details_tabs))
 				addItem("details_appearance_nav", R.string.details_appearance, R.string.details_appearance_summary, crumbs, AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_DETAILS_UI, R.string.details_ui, breadcrumbs = crumbs + ctx.getString(R.string.details_appearance), fragmentClass = PreviewSettingsFragment::class.java, keywordRes = intArrayOf(R.string.details_ui_compact, R.string.details_ui_expressive))
+				addItem(AppSettings.KEY_DETAILS_BACKDROP, R.string.details_backdrop, R.string.details_backdrop_summary, crumbs + ctx.getString(R.string.details_appearance), PreviewSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, ctx.getString(R.string.main_screen)) { crumbs ->
 				addItem(AppSettings.KEY_SEARCH_SUGGESTION_TYPES, R.string.search_suggestions, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
@@ -99,7 +108,23 @@ class SettingsSearchHelper @Inject constructor(
 			group(sectionCrumbs, ctx.getString(R.string.privacy)) { crumbs ->
 				addItem(AppSettings.KEY_PROTECT_APP, R.string.require_unlock, R.string.require_unlock_summary, crumbs, AppearanceSettingsFragment::class.java)
 				addItem(AppSettings.KEY_PROTECT_APP_TIMEOUT, R.string.require_unlock_after, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
-				addItem(AppSettings.KEY_SCREENSHOTS_POLICY, R.string.screenshots_policy, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SCREENSHOTS_POLICY, R.string.screenshots_policy, breadcrumbs = crumbs, fragmentClass = AppearanceSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.screenshots_policy))
+			}
+		}
+
+		section(R.string.google_drive_sync, SyncSettingsFragment::class.java) { sectionCrumbs ->
+			group(sectionCrumbs, ctx.getString(R.string.sync_account)) { crumbs ->
+				addItem("sync_sign_in", R.string.sync_sign_in, R.string.sync_sign_in_summary, crumbs, SyncSettingsFragment::class.java)
+				addItem("sync_sign_out", R.string.sync_sign_out, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java)
+				addItem("sync_account", R.string.sync_account, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java, keywordRes = intArrayOf(R.string.sync_hide_email, R.string.sync_show_email))
+			}
+			group(sectionCrumbs, ctx.getString(R.string.options)) { crumbs ->
+				addItem("sync_now", R.string.sync_now, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java, keywordRes = intArrayOf(R.string.sync_never, R.string.sync_syncing), keywordText = listOf("last synced"))
+				addItem("sync_frequency", R.string.sync_frequency, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java, keywordRes = intArrayOf(R.string.sync_freq_off, R.string.sync_freq_6h, R.string.sync_freq_12h, R.string.sync_freq_daily, R.string.sync_freq_weekly))
+				addItem("sync_wifi_only", R.string.sync_wifi_only, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java)
+				addItem("sync_on_start", R.string.sync_on_start, R.string.sync_on_start_summary, crumbs, SyncSettingsFragment::class.java)
+				addItem("sync_what", R.string.sync_what, breadcrumbs = crumbs, fragmentClass = SyncSettingsFragment::class.java, keywordRes = intArrayOf(R.string.sync_content_favourites, R.string.sync_content_history, R.string.sync_content_bookmarks, R.string.sync_content_feed, R.string.sync_content_tracking, R.string.sync_content_stats, R.string.sync_content_settings, R.string.sync_content_covers))
+				addItem("sync_delete_data", R.string.sync_delete_data, R.string.sync_delete_data_summary, crumbs, SyncSettingsFragment::class.java)
 			}
 		}
 
@@ -114,7 +139,7 @@ class SettingsSearchHelper @Inject constructor(
 			group(sectionCrumbs, ctx.getString(R.string.filter)) { crumbs ->
 				addItem(AppSettings.KEY_DISABLE_NSFW, R.string.disable_nsfw, R.string.disable_nsfw_summary, crumbs, ExtensionsSettingsFragment::class.java)
 				addItem(AppSettings.KEY_TAGS_WARNINGS, R.string.tags_warnings, R.string.tags_warnings_summary, crumbs, ExtensionsSettingsFragment::class.java)
-				addItem(AppSettings.KEY_INCOGNITO_NSFW, R.string.incognito_for_nsfw, breadcrumbs = crumbs, fragmentClass = ExtensionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_INCOGNITO_NSFW, R.string.incognito_for_nsfw, breadcrumbs = crumbs, fragmentClass = ExtensionsSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.incognito_nsfw_options))
 			}
 			group(sectionCrumbs, ctx.getString(R.string.handle_links)) { crumbs ->
 				addItem(AppSettings.KEY_HANDLE_LINKS, R.string.handle_links, R.string.handle_links_summary, crumbs, ExtensionsSettingsFragment::class.java)
@@ -123,33 +148,33 @@ class SettingsSearchHelper @Inject constructor(
 
 		section(R.string.reader_settings, ReaderSettingsFragment::class.java) { sectionCrumbs ->
 			group(sectionCrumbs, "Mode") { crumbs ->
-				addItem(AppSettings.KEY_READER_MODE, R.string.default_mode, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_MODE, R.string.default_mode, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.reader_modes))
 				addItem(AppSettings.KEY_READER_MODE_DETECT, R.string.detect_reader_mode, R.string.detect_reader_mode_summary, crumbs, ReaderSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, "Zoom") { crumbs ->
-				addItem(AppSettings.KEY_ZOOM_MODE, R.string.scale_mode, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_ZOOM_MODE, R.string.scale_mode, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.zoom_modes))
 				addItem(AppSettings.KEY_READER_ZOOM_BUTTONS, R.string.reader_zoom_buttons, R.string.reader_zoom_buttons_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_WEBTOON_ZOOM, R.string.webtoon_zoom, R.string.webtoon_zoom_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_WEBTOON_ZOOM_OUT, R.string.default_webtoon_zoom_out, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_WEBTOON_GAPS, R.string.webtoon_gaps, R.string.webtoon_gaps_summary, crumbs, ReaderSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, "Controls") { crumbs ->
-				addItem(AppSettings.KEY_READER_CONTROLS, R.string.reader_controls_in_bottom_bar, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_CONTROLS, R.string.reader_controls_in_bottom_bar, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.reader_controls))
 				addItem("reader_tap_actions", R.string.reader_actions, R.string.reader_actions_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READER_CONTROL_LTR, R.string.reader_control_ltr, R.string.reader_control_ltr_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READER_VOLUME_BUTTONS, R.string.switch_pages_volume_buttons, R.string.switch_pages_volume_buttons_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READER_NAVIGATION_INVERTED, R.string.reader_navigation_inverted, R.string.reader_navigation_inverted_summary, crumbs, ReaderSettingsFragment::class.java)
-				addItem(AppSettings.KEY_READER_ANIMATION, R.string.pages_animation, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_ANIMATION, R.string.pages_animation, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.reader_animation))
 				addItem(AppSettings.KEY_WEBTOON_PULL_GESTURE, R.string.enable_pull_gesture_title, R.string.enable_pull_gesture_summary, crumbs, ReaderSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, "Image") { crumbs ->
 				addItem(AppSettings.KEY_32BIT_COLOR, R.string.enhanced_colors, R.string.enhanced_colors_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READER_OPTIMIZE, R.string.reader_optimize, R.string.reader_optimize_summary, crumbs, ReaderSettingsFragment::class.java)
-				addItem(AppSettings.KEY_READER_CROP, R.string.crop_pages, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_CROP, R.string.crop_pages, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.reader_crop))
 			}
 			group(sectionCrumbs, "Display") { crumbs ->
 				addItem(AppSettings.KEY_READER_FULLSCREEN, R.string.fullscreen_mode, R.string.reader_fullscreen_summary, crumbs, ReaderSettingsFragment::class.java)
-				addItem(AppSettings.KEY_READER_ORIENTATION, R.string.screen_orientation, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_ORIENTATION, R.string.screen_orientation, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.screen_orientations))
 				addItem(AppSettings.KEY_READER_SCREEN_ON, R.string.keep_screen_on, R.string.keep_screen_on_summary, crumbs, ReaderSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READER_MULTITASK, R.string.reader_multitask, R.string.reader_multitask_summary, crumbs, ReaderSettingsFragment::class.java)
 			}
@@ -159,22 +184,39 @@ class SettingsSearchHelper @Inject constructor(
 				addItem(AppSettings.KEY_READER_CHAPTER_TOAST, R.string.reader_chapter_toast, R.string.reader_chapter_toast_summary, crumbs, ReaderSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, "Background") { crumbs ->
-				addItem(AppSettings.KEY_READER_BACKGROUND, R.string.background, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_READER_BACKGROUND, R.string.background, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.reader_backgrounds))
 				addItem(AppSettings.KEY_PAGES_NUMBERS, R.string.show_pages_numbers, R.string.show_pages_numbers_summary, crumbs, ReaderSettingsFragment::class.java)
-				addItem(AppSettings.KEY_PAGES_PRELOAD, R.string.preload_pages, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java)
+				addItem(AppSettings.KEY_PAGES_PRELOAD, R.string.preload_pages, breadcrumbs = crumbs, fragmentClass = ReaderSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.network_policy))
 			}
 		}
 
 		section(R.string.storage_and_network, StorageAndNetworkSettingsFragment::class.java) { sectionCrumbs ->
 			group(sectionCrumbs, ctx.getString(R.string.storage_usage)) { crumbs ->
 				addItem("data_removal", R.string.data_removal, breadcrumbs = crumbs, fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SEARCH_HISTORY_CLEAR, R.string.clear_search_history, breadcrumbs = crumbs + ctx.getString(R.string.data_removal), fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_UPDATES_FEED_CLEAR, R.string.clear_updates_feed, breadcrumbs = crumbs + ctx.getString(R.string.data_removal), fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_THUMBS_CACHE_CLEAR, R.string.clear_thumbs_cache, breadcrumbs = crumbs + ctx.getString(R.string.data_removal), fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_PAGES_CACHE_CLEAR, R.string.clear_pages_cache, breadcrumbs = crumbs + ctx.getString(R.string.data_removal), fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_HTTP_CACHE_CLEAR, R.string.clear_network_cache, breadcrumbs = crumbs + ctx.getString(R.string.data_removal), fragmentClass = DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_CLEAR_MANGA_DATA, R.string.clear_database, R.string.clear_database_summary, crumbs + ctx.getString(R.string.data_removal), DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_COOKIES_CLEAR, R.string.clear_cookies, R.string.clear_cookies_summary, crumbs + ctx.getString(R.string.data_removal), DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_WEBVIEW_CLEAR, R.string.clear_browser_data, R.string.clear_browser_data_summary, crumbs + ctx.getString(R.string.data_removal), DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_CHAPTERS_CLEAR, R.string.delete_read_chapters, R.string.delete_read_chapters_summary, crumbs + ctx.getString(R.string.data_removal), DataCleanupSettingsFragment::class.java)
+				addItem(AppSettings.KEY_CHAPTERS_CLEAR_AUTO, R.string.delete_read_chapters_auto, R.string.runs_on_app_start, crumbs + ctx.getString(R.string.data_removal), DataCleanupSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, "Network") { crumbs ->
-				addItem(AppSettings.KEY_PREFETCH_CONTENT, R.string.prefetch_content, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java)
-				addItem(AppSettings.KEY_PAGES_PRELOAD, R.string.preload_pages, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java)
+				addItem(AppSettings.KEY_PREFETCH_CONTENT, R.string.prefetch_content, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.network_policy))
+				addItem(AppSettings.KEY_PAGES_PRELOAD, R.string.preload_pages, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.network_policy))
 				addItem("proxy", R.string.proxy, breadcrumbs = crumbs, fragmentClass = ProxySettingsFragment::class.java)
-				addItem(AppSettings.KEY_DOH, R.string.dns_over_https, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java)
-				addItem(AppSettings.KEY_IMAGES_PROXY, R.string.images_proxy_title, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java)
+				addItem(AppSettings.KEY_PROXY_TYPE, R.string.type, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.proxy_types))
+				addItem(AppSettings.KEY_PROXY_ADDRESS, R.string.address, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java)
+				addItem(AppSettings.KEY_PROXY_PORT, R.string.port, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java)
+				addItem(AppSettings.KEY_PROXY_LOGIN, R.string.username, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java)
+				addItem(AppSettings.KEY_PROXY_PASSWORD, R.string.password, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java)
+				addItem("proxy_test_connection", R.string.test_connection, breadcrumbs = crumbs + ctx.getString(R.string.proxy), fragmentClass = ProxySettingsFragment::class.java)
+				addItem(AppSettings.KEY_DOH, R.string.dns_over_https, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.doh_providers))
+				addItem(AppSettings.KEY_MIHON_USER_AGENT, R.string.user_agent, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java, keywordText = listOf("webview", "browser", "mihon"))
+				addItem(AppSettings.KEY_IMAGES_PROXY, R.string.images_proxy_title, breadcrumbs = crumbs, fragmentClass = StorageAndNetworkSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.image_proxies))
 				addItem(AppSettings.KEY_SSL_BYPASS, R.string.ignore_ssl_errors, R.string.ignore_ssl_errors_summary, crumbs, StorageAndNetworkSettingsFragment::class.java)
 				addItem(AppSettings.KEY_OFFLINE_DISABLED, R.string.disable_connectivity_check, R.string.disable_connectivity_check_summary, crumbs, StorageAndNetworkSettingsFragment::class.java)
 				addItem(AppSettings.KEY_ADBLOCK, R.string.adblock, R.string.adblock_summary, crumbs, StorageAndNetworkSettingsFragment::class.java)
@@ -185,8 +227,8 @@ class SettingsSearchHelper @Inject constructor(
 			group(sectionCrumbs, "General") { crumbs ->
 				addItem(AppSettings.KEY_LOCAL_MANGA_DIRS, R.string.local_manga_directories, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java)
 				addItem(AppSettings.KEY_LOCAL_STORAGE, R.string.manga_save_location, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java)
-				addItem(AppSettings.KEY_DOWNLOADS_FORMAT, R.string.preferred_download_format, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java)
-				addItem(AppSettings.KEY_DOWNLOADS_METERED_NETWORK, R.string.download_over_cellular, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_DOWNLOADS_FORMAT, R.string.preferred_download_format, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.download_formats))
+				addItem(AppSettings.KEY_DOWNLOADS_METERED_NETWORK, R.string.download_over_cellular, breadcrumbs = crumbs, fragmentClass = DownloadsSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.metered_network_options))
 				addItem("ignore_dose", R.string.disable_battery_optimization, R.string.disable_battery_optimization_summary_downloads, crumbs, DownloadsSettingsFragment::class.java)
 			}
 			group(sectionCrumbs, ctx.getString(R.string.pages_saving)) { crumbs ->
@@ -210,11 +252,15 @@ class SettingsSearchHelper @Inject constructor(
 			group(sectionCrumbs, "Tracker") { crumbs ->
 				addItem(AppSettings.KEY_TRACKER_ENABLED, R.string.check_new_chapters_title, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
 				addItem(AppSettings.KEY_TRACKER_WIFI_ONLY, R.string.only_using_wifi, R.string.tracker_wifi_only_summary, crumbs, TrackerSettingsFragment::class.java)
-				addItem(AppSettings.KEY_TRACKER_FREQUENCY, R.string.frequency_of_check, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
-				addItem(AppSettings.KEY_TRACK_SOURCES, R.string.track_sources, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
+				addItem(AppSettings.KEY_TRACKER_FREQUENCY, R.string.frequency_of_check, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.tracker_frequency))
+				addItem(AppSettings.KEY_TRACK_SOURCES, R.string.track_sources, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java, keywordArrayRes = intArrayOf(R.array.track_sources))
 				addItem("track_categories", R.string.favourites_categories, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
 				addItem("notifications_settings", R.string.notifications_settings, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
 				addItem("notifications", R.string.notifications, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
+				addItem(AppSettings.KEY_TRACKER_NOTIFICATIONS, R.string.notifications_enable, breadcrumbs = crumbs + ctx.getString(R.string.notifications), fragmentClass = NotificationSettingsLegacyFragment::class.java)
+				addItem(AppSettings.KEY_NOTIFICATIONS_SOUND, R.string.notification_sound, breadcrumbs = crumbs + ctx.getString(R.string.notifications), fragmentClass = NotificationSettingsLegacyFragment::class.java)
+				addItem(AppSettings.KEY_NOTIFICATIONS_VIBRATE, R.string.vibration, breadcrumbs = crumbs + ctx.getString(R.string.notifications), fragmentClass = NotificationSettingsLegacyFragment::class.java)
+				addItem(AppSettings.KEY_NOTIFICATIONS_LIGHT, R.string.light_indicator, breadcrumbs = crumbs + ctx.getString(R.string.notifications), fragmentClass = NotificationSettingsLegacyFragment::class.java)
 				addItem(AppSettings.KEY_TRACKER_NO_NSFW, R.string.disable_nsfw_notifications, R.string.disable_nsfw_notifications_summary, crumbs, TrackerSettingsFragment::class.java)
 				addItem(AppSettings.KEY_TRACKER_DOWNLOAD, R.string.download_new_chapters, breadcrumbs = crumbs, fragmentClass = TrackerSettingsFragment::class.java)
 			}
@@ -227,7 +273,12 @@ class SettingsSearchHelper @Inject constructor(
 
 		section(R.string.services, ServicesSettingsFragment::class.java) { sectionCrumbs ->
 			group(sectionCrumbs, "General") { crumbs ->
-				addItem(AppSettings.KEY_SUGGESTIONS, R.string.suggestions, breadcrumbs = crumbs, fragmentClass = SuggestionsSettingsFragment::class.java)
+				addItem("suggestions_screen", R.string.suggestions, breadcrumbs = crumbs, fragmentClass = SuggestionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SUGGESTIONS, R.string.suggestions_enable, breadcrumbs = crumbs + ctx.getString(R.string.suggestions), fragmentClass = SuggestionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SUGGESTIONS_WIFI_ONLY, R.string.only_using_wifi, R.string.suggestions_wifi_only_summary, crumbs + ctx.getString(R.string.suggestions), SuggestionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SUGGESTIONS_NOTIFICATIONS, R.string.notifications_enable, R.string.suggestions_notifications_summary, crumbs + ctx.getString(R.string.suggestions), SuggestionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SUGGESTIONS_EXCLUDE_TAGS, R.string.suggestions_excluded_genres, R.string.suggestions_excluded_genres_summary, crumbs + ctx.getString(R.string.suggestions), SuggestionsSettingsFragment::class.java)
+				addItem(AppSettings.KEY_SUGGESTIONS_EXCLUDE_NSFW, R.string.exclude_nsfw_from_suggestions, R.string.exclude_nsfw_from_suggestions_summary, crumbs + ctx.getString(R.string.suggestions), SuggestionsSettingsFragment::class.java)
 				addItem(AppSettings.KEY_RELATED_MANGA, R.string.related_manga, R.string.related_manga_summary, crumbs, ServicesSettingsFragment::class.java)
 				addItem(AppSettings.KEY_STATS_ENABLED, R.string.reading_stats, breadcrumbs = crumbs, fragmentClass = ServicesSettingsFragment::class.java)
 				addItem(AppSettings.KEY_READING_TIME, R.string.reading_time_estimation, R.string.reading_time_estimation_summary, crumbs, ServicesSettingsFragment::class.java)
@@ -240,6 +291,8 @@ class SettingsSearchHelper @Inject constructor(
 			}
 			group(sectionCrumbs, "External") { crumbs ->
 				addItem("discord_rpc", R.string.discord_rpc, R.string.discord_rpc_summary, crumbs, DiscordSettingsFragment::class.java)
+				addItem("discord_token", R.string.discord_token, breadcrumbs = crumbs + ctx.getString(R.string.discord), fragmentClass = DiscordSettingsFragment::class.java, keywordText = listOf("token", "sign in", "browser"))
+				addItem("discord_skip_nsfw", R.string.disable_nsfw, R.string.rpc_skip_nsfw_summary, crumbs + ctx.getString(R.string.discord), DiscordSettingsFragment::class.java)
 			}
 		}
 
@@ -264,6 +317,7 @@ class SettingsSearchHelper @Inject constructor(
 		key: String,
 		summary: String,
 		breadcrumbs: List<String>,
+		keywords: List<String>,
 	): String = buildString {
 		append(title)
 		append(' ')
@@ -275,6 +329,10 @@ class SettingsSearchHelper @Inject constructor(
 		if (breadcrumbs.isNotEmpty()) {
 			append(' ')
 			append(breadcrumbs.joinToString(" "))
+		}
+		if (keywords.isNotEmpty()) {
+			append(' ')
+			append(keywords.joinToString(" "))
 		}
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.plus
 import org.koitharu.kotatsu.core.ui.BaseViewModel
 import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
 import org.koitharu.kotatsu.core.util.ext.call
+import java.text.Normalizer
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,7 +28,23 @@ class SettingsSearchViewModel @Inject constructor(
 		if (q == null) {
 			emptyList()
 		} else {
-			allSettings.filter { it.searchText.contains(q, ignoreCase = true) }
+			val normalizedQuery = q.normalizeSearchText()
+			if (normalizedQuery.isBlank()) {
+				allSettings
+			} else {
+				val tokens = normalizedQuery.split(' ').filter { it.isNotBlank() }
+				allSettings.asSequence()
+					.mapNotNull { item ->
+						item.matchScore(normalizedQuery, tokens)?.let { score -> item to score }
+					}
+					.sortedWith(
+						compareBy<Pair<SettingsItem, Int>> { it.second }
+							.thenBy { it.first.breadcrumbs.joinToString(" > ") }
+							.thenBy { it.first.title.toString() },
+					)
+					.map { it.first }
+					.toList()
+			}
 		}
 	}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Lazily, emptyList())
 
@@ -56,5 +73,38 @@ class SettingsSearchViewModel @Inject constructor(
 	fun navigateToPreference(item: SettingsItem) {
 		discardSearch()
 		onNavigateToPreference.call(item)
+	}
+
+	private fun SettingsItem.matchScore(query: String, tokens: List<String>): Int? {
+		val normalizedTitle = title.toString().normalizeSearchText()
+		val normalizedText = searchText.normalizeSearchText()
+		return when {
+			normalizedTitle == query -> 0
+			normalizedTitle.startsWith(query) -> 1
+			normalizedText.startsWith(query) -> 2
+			tokens.all { normalizedTitle.contains(it) } -> 3
+			tokens.all { normalizedText.contains(it) } -> 4
+			else -> null
+		}
+	}
+
+	private fun String.normalizeSearchText(): String {
+		val decomposed = Normalizer.normalize(this, Normalizer.Form.NFD)
+		return buildString(decomposed.length) {
+			var lastWasSpace = true
+			decomposed.forEach { char ->
+				when {
+					Character.getType(char) == Character.NON_SPACING_MARK.toInt() -> Unit
+					char.isLetterOrDigit() -> {
+						append(char.lowercaseChar())
+						lastWasSpace = false
+					}
+					!lastWasSpace -> {
+						append(' ')
+						lastWasSpace = true
+					}
+				}
+			}
+		}.trim()
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/search/SettingsSearchViewModel.kt
@@ -57,9 +57,7 @@ class SettingsSearchViewModel @Inject constructor(
 		get() = query.value.orEmpty()
 
 	fun onQueryChanged(value: String) {
-		if (query.value != null) {
-			query.value = value
-		}
+		query.value = value
 	}
 
 	fun discardSearch() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/SourceSettingsFragment.kt
@@ -140,7 +140,10 @@ class SourceSettingsFragment : BaseComposeSettingsFragment(0) {
 					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
 					onOpenBrowser = { url -> openBrowser(url) },
 					onUninstall = { pkg -> uninstallExtension(pkg) },
-					onLanguageSelected = { lang -> viewModel.setActiveLanguage(lang) },
+					onLanguageSelected = { lang ->
+						viewModel.setActiveLanguage(lang)
+						requireActivity().recreate()
+					},
 				)
 			}
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/GoogleDriveApi.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/GoogleDriveApi.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.encodeToStream
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -52,10 +54,14 @@ class GoogleDriveApi @Inject constructor(
 		// as an optimistic-concurrency token to detect a concurrent write from another device. Drive
 		// encodes int64 fields as JSON strings, so this is a String and only ever compared for equality.
 		@SerialName("version") val version: String? = null,
+		@SerialName("etag") val etag: String? = null,
 	)
 
 	@Serializable
-	private class FileVersion(@SerialName("version") val version: String? = null)
+	class FileVersion(
+		@SerialName("version") val version: String? = null,
+		@SerialName("etag") val etag: String? = null,
+	)
 
 	@Serializable
 	class DriveUser(
@@ -65,7 +71,10 @@ class GoogleDriveApi @Inject constructor(
 	)
 
 	@Serializable
-	private class FileList(@SerialName("files") val files: List<DriveFile> = emptyList())
+	private class FileList(
+		@SerialName("files") val files: List<DriveFile> = emptyList(),
+		@SerialName("nextPageToken") val nextPageToken: String? = null,
+	)
 
 	@Serializable
 	private class AboutResponse(@SerialName("user") val user: DriveUser? = null)
@@ -88,54 +97,88 @@ class GoogleDriveApi @Inject constructor(
 	 * them. Trashed files are excluded so a not-yet-purged delete can't shadow the live file.
 	 */
 	suspend fun findSyncFiles(token: String): List<DriveFile> = withContext(Dispatchers.IO) {
-		val url = "$DRIVE_BASE/files".toHttpUrl().newBuilder()
-			.addQueryParameter("spaces", "appDataFolder")
-			.addQueryParameter("q", "name = '$FILE_NAME' and trashed = false")
-			.addQueryParameter("fields", "files(id,name,modifiedTime,createdTime,version)")
-			.addQueryParameter("orderBy", "createdTime")
-			.addQueryParameter("pageSize", "100")
-			.build()
-		val request = Request.Builder().url(url).get().authorize(token).build()
-		httpClient.newCall(request).execute().parse<FileList>()?.files.orEmpty()
+		val files = mutableListOf<DriveFile>()
+		var pageToken: String? = null
+		do {
+			val url = "$DRIVE_BASE/files".toHttpUrl().newBuilder().apply {
+				addQueryParameter("spaces", "appDataFolder")
+				addQueryParameter("q", "name = '$FILE_NAME' and trashed = false")
+				addQueryParameter("fields", "nextPageToken,files(id,name,modifiedTime,createdTime,version,etag)")
+				addQueryParameter("orderBy", "createdTime")
+				addQueryParameter("pageSize", "100")
+				if (pageToken != null) {
+					addQueryParameter("pageToken", pageToken)
+				}
+			}.build()
+			val request = Request.Builder().url(url).get().authorize(token).build()
+			val response = httpClient.newCall(request).execute().parse<FileList>()
+			if (response != null) {
+				files.addAll(response.files)
+				pageToken = response.nextPageToken
+			} else {
+				pageToken = null
+			}
+		} while (pageToken != null)
+		files
 	}
 
 	/** Reads just the current [DriveFile.version] of a file, for a pre-upload concurrency re-check. */
-	suspend fun getFileVersion(token: String, fileId: String): String? = withContext(Dispatchers.IO) {
+	suspend fun getFileVersion(token: String, fileId: String): FileVersion? = withContext(Dispatchers.IO) {
 		val url = "$DRIVE_BASE/files/$fileId".toHttpUrl().newBuilder()
-			.addQueryParameter("fields", "version")
+			.addQueryParameter("fields", "version,etag")
 			.build()
 		val request = Request.Builder().url(url).get().authorize(token).build()
-		httpClient.newCall(request).execute().parse<FileVersion>()?.version
+		httpClient.newCall(request).execute().parse<FileVersion>()
 	}
 
 	/** Downloads the raw sync file content (plain JSON bytes). */
-	suspend fun download(token: String, fileId: String): ByteArray = withContext(Dispatchers.IO) {
+	suspend fun <T> download(token: String, fileId: String, block: (okio.BufferedSource) -> T): T = withContext(Dispatchers.IO) {
 		val url = "$DRIVE_BASE/files/$fileId".toHttpUrl().newBuilder()
 			.addQueryParameter("alt", "media")
 			.build()
 		val request = Request.Builder().url(url).get().authorize(token).build()
 		httpClient.newCall(request).execute().use { response ->
 			if (!response.isSuccessful) throw response.toError()
-			response.body.bytes()
+			block(response.body.source())
 		}
 	}
 
 	/**
-	 * Uploads [content] (plain JSON bytes). Creates the file in appDataFolder when [fileId] is null
+	 * Uploads [snapshot] (plain JSON bytes). Creates the file in appDataFolder when [fileId] is null
 	 * (a metadata-only create followed by a media upload — avoids the fragile multipart path),
 	 * otherwise overwrites the existing file. Returns the file id.
 	 */
-	suspend fun upload(token: String, content: ByteArray, fileId: String?): String =
+	suspend fun upload(
+		token: String,
+		snapshot: org.koitharu.kotatsu.sync.data.model.SyncSnapshot,
+		fileId: String?,
+		expectedEtag: String? = null
+	): String =
 		withContext(Dispatchers.IO) {
 			val targetId = fileId ?: createEmptyFile(token)
 			val url = "$UPLOAD_BASE/files/$targetId".toHttpUrl().newBuilder()
 				.addQueryParameter("uploadType", "media")
 				.addQueryParameter("fields", "id")
 				.build()
+
+			val requestBody = object : okhttp3.RequestBody() {
+				override fun contentType() = JSON_MEDIA_TYPE
+				override fun writeTo(sink: okio.BufferedSink) {
+					@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+					json.encodeToStream(org.koitharu.kotatsu.sync.data.model.SyncSnapshot.serializer(), snapshot, sink.outputStream())
+				}
+			}
+
 			val request = Request.Builder()
 				.url(url)
-				.patch(content.toRequestBody(JSON_MEDIA_TYPE))
+				.patch(requestBody)
 				.authorize(token)
+				.apply {
+					if (expectedEtag != null) {
+						val formattedEtag = if (expectedEtag.startsWith("\"")) expectedEtag else "\"$expectedEtag\""
+						header("If-Match", formattedEtag)
+					}
+				}
 				.build()
 			httpClient.newCall(request).execute().parse<IdResponse>()?.id ?: targetId
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/GoogleDriveSyncRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/GoogleDriveSyncRepository.kt
@@ -8,9 +8,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 import org.koitharu.kotatsu.backup.local.data.model.BackupPrimitive
 import org.koitharu.kotatsu.backup.local.data.model.BookmarkBackup
 import org.koitharu.kotatsu.backup.local.data.model.MangaBackup
@@ -40,6 +42,7 @@ import javax.inject.Singleton
 sealed interface SyncResult {
 	data object Success : SyncResult
 	data object SignInRequired : SyncResult
+	data object AlreadyRunning : SyncResult
 
 	/** [retryable] is false for errors that won't fix themselves (e.g. a newer remote format). */
 	data class Error(val message: String?, val retryable: Boolean = true) : SyncResult
@@ -86,7 +89,7 @@ class GoogleDriveSyncRepository @Inject constructor(
 
 	suspend fun sync(): SyncResult {
 		if (!syncSettings.isSignedIn) return SyncResult.SignInRequired
-		if (!syncMutex.tryLock()) return SyncResult.Success
+		if (!syncMutex.tryLock()) return SyncResult.AlreadyRunning
 		isSyncing.value = true
 		try {
 			var token = auth.requireAccessToken()
@@ -141,8 +144,9 @@ class GoogleDriveSyncRepository @Inject constructor(
 			val remotes = ArrayList<SyncSnapshot>(files.size)
 			val decodedIds = HashSet<String>(files.size)
 			for (file in files) {
-				val bytes = api.download(token, file.id)
-				val snapshot = decodeSnapshot(bytes) // null == same-schema corruption → ignored
+				val snapshot = api.download(token, file.id) { source ->
+					decodeSnapshot(source)
+				}
 				if (snapshot != null) {
 					remotes += snapshot
 					decodedIds += file.id
@@ -175,17 +179,29 @@ class GoogleDriveSyncRepository @Inject constructor(
 			} else {
 				// Concurrency re-check immediately before writing: if the canonical file's version moved
 				// since we read it, another device wrote concurrently → re-merge before overwriting.
-				if (canonical != null && baseVersion != null && attempt < MAX_CONFLICT_RETRIES) {
+				if (canonical != null && baseVersion != null) {
 					val current = api.getFileVersion(token, canonical.id)
-					if (current != null && current != baseVersion) {
-						Log.w(TAG, "remote changed during sync (v$baseVersion → v$current); retrying merge")
+					if (current?.version != null && current.version != baseVersion) {
+						if (attempt < MAX_CONFLICT_RETRIES) {
+							Log.w(TAG, "remote changed during sync (v$baseVersion → v${current.version}); retrying merge")
+							attempt++
+							continue
+						} else {
+							throw SyncApiException(412, "Precondition failed: remote changed during sync on last attempt")
+						}
+					}
+				}
+				val fileId = try {
+					api.upload(token, upload, canonical?.id, canonical?.etag)
+				} catch (e: SyncApiException) {
+					if (e.code == 412 && attempt < MAX_CONFLICT_RETRIES) {
+						Log.w(TAG, "If-Match conflict on upload, retrying merge", e)
 						attempt++
 						continue
 					}
+					throw e
 				}
-				val payload = json.encodeToString(SyncSnapshot.serializer(), upload).encodeToByteArray()
-				val fileId = api.upload(token, payload, canonical?.id)
-				Log.i(TAG, "uploaded ${payload.size} bytes to $fileId")
+				Log.i(TAG, "uploaded snapshot to $fileId")
 				// Collapse first-run duplicates, but ONLY ones we decoded — their data is now merged into
 				// this write. An unreadable duplicate is left untouched rather than risk losing data we
 				// couldn't parse.
@@ -199,7 +215,7 @@ class GoogleDriveSyncRepository @Inject constructor(
 			}
 
 			// Shed old tombstones locally so the next snapshot we build is already trimmed.
-			gcOldTombstones(now)
+			gcOldTombstones(now, enabled)
 
 			syncSettings.lastSyncTimestamp = now
 			syncSettings.lastSyncError = null
@@ -229,25 +245,23 @@ class GoogleDriveSyncRepository @Inject constructor(
 
 	/**
 	 * Decodes a downloaded snapshot. Throws [SyncSchemaException] when the file declares a newer schema
-	 * than this build understands — so we abort rather than overwrite newer data. Returns null for
-	 * same-schema corruption, which the caller safely treats as "no usable remote".
+	 * than this build understands — so we abort rather than overwrite newer data.
 	 */
-	private fun decodeSnapshot(bytes: ByteArray): SyncSnapshot? {
-		val text = bytes.decodeToString()
-		if (text.isBlank()) return null
-		// Probe the schema first: a newer format may also fail the full decode, but we still must
-		// recognise it as "newer" rather than "corrupt" to avoid clobbering it.
+	private fun decodeSnapshot(source: okio.BufferedSource): SyncSnapshot? {
+		if (source.exhausted()) return null
+		val peekSource = source.peek()
 		val version = runCatching {
-			json.decodeFromString(SchemaProbe.serializer(), text).schemaVersion
+			@OptIn(ExperimentalSerializationApi::class)
+			json.decodeFromStream(SchemaProbe.serializer(), peekSource.inputStream()).schemaVersion
 		}.getOrNull()
 		if (version != null && version > SyncSnapshot.SCHEMA_VERSION) {
 			throw SyncSchemaException(version)
 		}
 		return try {
-			json.decodeFromString(SyncSnapshot.serializer(), text)
+			@OptIn(ExperimentalSerializationApi::class)
+			json.decodeFromStream(SyncSnapshot.serializer(), source.inputStream())
 		} catch (e: Exception) {
-			Log.w(TAG, "remote file unreadable (${e.message}); will overwrite with local data")
-			null
+			throw SyncApiException(0, "Remote file is corrupt or unreadable: ${e.message}")
 		}
 	}
 
@@ -297,12 +311,16 @@ class GoogleDriveSyncRepository @Inject constructor(
 		)
 	}
 
-	private suspend fun gcOldTombstones(now: Long) {
+	private suspend fun gcOldTombstones(now: Long, enabled: Set<SyncContent>) {
 		val cutoff = now - TOMBSTONE_TTL_MS
 		runCatchingCancellable {
-			database.getFavouritesDao().gc(cutoff)
-			database.getFavouriteCategoriesDao().gc(cutoff)
-			database.getHistoryDao().gc(cutoff)
+			if (SyncContent.FAVOURITES in enabled) {
+				database.getFavouritesDao().gc(cutoff)
+				database.getFavouriteCategoriesDao().gc(cutoff)
+			}
+			if (SyncContent.HISTORY in enabled) {
+				database.getHistoryDao().gc(cutoff)
+			}
 		}.onFailure { Log.w(TAG, "local tombstone gc failed", it) }
 	}
 
@@ -468,10 +486,18 @@ class GoogleDriveSyncRepository @Inject constructor(
 	) {
 		if (SyncContent.FAVOURITES in enabled) {
 			database.withTransaction {
+				val existingCategoryIds = database.getFavouriteCategoriesDao().findAllForSync()
+					.map { it.categoryId.toLong() }
+					.toMutableSet()
 				for (category in merged.categories) {
 					database.getFavouriteCategoriesDao().upsert(category.toEntity())
+					existingCategoryIds.add(category.categoryId.toLong())
 				}
 				for (favourite in merged.favourites) {
+					if (favourite.categoryId !in existingCategoryIds) {
+						Log.w(TAG, "Skipping orphan favourite for manga ${favourite.mangaId} referencing missing category ${favourite.categoryId}")
+						continue
+					}
 					upsertManga(favourite.manga)
 					database.getFavouritesDao().upsert(favourite.toEntity())
 				}
@@ -525,12 +551,76 @@ class GoogleDriveSyncRepository @Inject constructor(
 		}
 	}
 
+	private fun validateSetting(key: String, value: BackupPrimitive): Boolean {
+		if (key in EXCLUDED_SETTINGS_KEYS) return false
+		return when (key) {
+			AppSettings.KEY_ADBLOCK,
+			AppSettings.KEY_TITLE_OVER_COVER,
+			AppSettings.KEY_GRID_SPACING_INCREASED,
+			AppSettings.KEY_THEME_AMOLED,
+			AppSettings.KEY_HAPTIC_FEEDBACK,
+			AppSettings.KEY_OFFLINE_DISABLED,
+			AppSettings.KEY_READER_DOUBLE_PAGES,
+			AppSettings.KEY_READER_DOUBLE_FOLDABLE,
+			AppSettings.KEY_READER_ZOOM_BUTTONS,
+			AppSettings.KEY_READER_CONTROL_LTR,
+			AppSettings.KEY_READER_NAVIGATION_INVERTED,
+			AppSettings.KEY_READER_FULLSCREEN,
+			AppSettings.KEY_READER_VOLUME_BUTTONS,
+			AppSettings.KEY_READER_MODE_DETECT,
+			AppSettings.KEY_READER_CROP,
+			AppSettings.KEY_READER_SCREEN_ON,
+			AppSettings.KEY_PAGES_NUMBERS,
+			AppSettings.KEY_TRACKER_ENABLED,
+			AppSettings.KEY_TRACKER_WIFI_ONLY,
+			AppSettings.KEY_TRACK_SOURCES,
+			AppSettings.KEY_TRACKER_NOTIFICATIONS,
+			AppSettings.KEY_TRACKER_NO_NSFW,
+			AppSettings.KEY_NOTIFICATIONS_SOUND,
+			AppSettings.KEY_NOTIFICATIONS_VIBRATE,
+			AppSettings.KEY_NOTIFICATIONS_LIGHT,
+			"discord_rpc_enabled" -> value is BackupPrimitive.BoolValue
+
+			AppSettings.KEY_LIST_MODE,
+			AppSettings.KEY_LIST_MODE_HISTORY,
+			AppSettings.KEY_LIST_MODE_FAVORITES,
+			AppSettings.KEY_LIST_MODE_SUGGESTIONS,
+			AppSettings.KEY_THEME,
+			AppSettings.KEY_COLOR_THEME,
+			AppSettings.KEY_READER_ANIMATION,
+			AppSettings.KEY_READER_BACKGROUND,
+			AppSettings.KEY_READER_CONTROLS,
+			AppSettings.KEY_READER_MODE,
+			AppSettings.KEY_TRACKER_FREQUENCY,
+			AppSettings.KEY_TRACKER_DOWNLOAD,
+			AppSettings.KEY_PAGES_PRELOAD,
+			AppSettings.KEY_DOWNLOADS_METERED_NETWORK,
+			AppSettings.KEY_SEARCH_SUGGESTION_TYPES,
+			AppSettings.KEY_MANGA_LIST_BADGES -> value is BackupPrimitive.StringValue
+
+			AppSettings.KEY_GRID_SIZE,
+			AppSettings.KEY_GRID_SIZE_PAGES -> {
+				value is BackupPrimitive.IntValue && value.value in 1..10
+			}
+
+			AppSettings.KEY_READER_DOUBLE_PAGES_SENSITIVITY -> {
+				value is BackupPrimitive.FloatValue && value.value in 0f..1f
+			}
+
+			AppSettings.KEY_READER_ORIENTATION -> {
+				value is BackupPrimitive.IntValue || value is BackupPrimitive.StringValue
+			}
+
+			else -> false
+		}
+	}
+
 	private suspend fun applyConfig(config: SyncConfig, enabled: Set<SyncContent>) {
 		if (SyncContent.SETTINGS in enabled) {
-			val settings = config.settings.toMutableMap()
-			EXCLUDED_SETTINGS_KEYS.forEach { settings.remove(it) }
+			val settings = config.settings.filter { (key, value) -> validateSetting(key, value) }
 			appSettings.upsertAll(settings.mapValues { it.value.rawValue() })
-			tapGridSettings.upsertAll(config.readerGrid.mapValues { it.value.rawValue() })
+			val readerGrid = config.readerGrid.filter { (key, value) -> value is BackupPrimitive.StringValue }
+			tapGridSettings.upsertAll(readerGrid.mapValues { it.value.rawValue() })
 			applySourceSettings(config.sourceSettings)
 		}
 		if (SyncContent.CUSTOM_COVERS in enabled) {
@@ -632,11 +722,14 @@ class GoogleDriveSyncRepository @Inject constructor(
 	private fun dumpAppSettings(): Map<String, BackupPrimitive> {
 		val map = appSettings.getAllValues().toMutableMap()
 		EXCLUDED_SETTINGS_KEYS.forEach { map.remove(it) }
-		return map.toSortedMap().mapNotNullValuesToBackup()
+		val backupMap = map.toSortedMap().mapNotNullValuesToBackup()
+		return backupMap.filter { (key, value) -> validateSetting(key, value) }
 	}
 
-	private fun dumpReaderGrid(): Map<String, BackupPrimitive> =
-		tapGridSettings.getAllValues().toSortedMap().mapNotNullValuesToBackup()
+	private fun dumpReaderGrid(): Map<String, BackupPrimitive> {
+		val backupMap = tapGridSettings.getAllValues().toSortedMap().mapNotNullValuesToBackup()
+		return backupMap.filter { (key, value) -> value is BackupPrimitive.StringValue }
+	}
 
 	private suspend fun dumpSourceSettings(): List<SourceSettingsBackup> {
 		val sources = database.getSourcesDao().findAll()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncMerger.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncMerger.kt
@@ -55,7 +55,7 @@ object SyncMerger {
 			local,
 			remote,
 			key = { Triple(it.scrobbler, it.id, it.mangaId) },
-			timestamp = { it.chapter.toLong() },
+			timestamp = { it.updatedAt },
 		)
 
 	/** Union of bookmark groups by manga, and of items within a group by page (local wins). */

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncSettingsFragment.kt
@@ -263,7 +263,7 @@ private fun SyncScreen(
 							subtitle = stringResource(R.string.sync_on_start_summary),
 							checked = state.isSyncOnStart,
 							onCheckedChange = onSyncOnStartChange,
-							icon = R.drawable.ic_sync,
+							icon = R.drawable.ic_play,
 							shape = pos.shape,
 						)
 					}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncSettingsViewModel.kt
@@ -83,6 +83,7 @@ class SyncSettingsViewModel @Inject constructor(
 	private suspend fun runSync() {
 		when (val result = repository.sync()) {
 			is SyncResult.Success -> events.call(SyncEvent.Message(R.string.sync_completed))
+			is SyncResult.AlreadyRunning -> events.call(SyncEvent.Message(R.string.sync_in_progress))
 			is SyncResult.SignInRequired -> events.call(SyncEvent.Error(null))
 			is SyncResult.Error -> events.call(SyncEvent.Error(result.message))
 		}
@@ -133,6 +134,7 @@ class SyncSettingsViewModel @Inject constructor(
 		launchLoadingJob(Dispatchers.Default) {
 			when (val result = repository.deleteRemoteData()) {
 				is SyncResult.Success -> events.call(SyncEvent.Message(R.string.sync_data_deleted))
+				is SyncResult.AlreadyRunning -> events.call(SyncEvent.Message(R.string.sync_in_progress))
 				is SyncResult.SignInRequired -> events.call(SyncEvent.Error(null))
 				is SyncResult.Error -> events.call(SyncEvent.Error(result.message))
 			}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/work/SyncWorker.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/work/SyncWorker.kt
@@ -45,13 +45,34 @@ class SyncWorker @AssistedInject constructor(
 		return try {
 			when (val result = repository.sync()) {
 				is SyncResult.Success -> Result.success()
-				is SyncResult.SignInRequired -> Result.failure()
+				is SyncResult.AlreadyRunning -> Result.success()
+				is SyncResult.SignInRequired -> {
+					postReauthNotification()
+					Result.failure()
+				}
 				is SyncResult.Error ->
 					if (result.retryable && runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.failure()
 			}
 		} catch (e: Exception) {
 			e.printStackTraceDebug()
 			if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else Result.failure()
+		}
+	}
+
+	private fun postReauthNotification() {
+		val context = applicationContext
+		createNotificationChannel(context)
+		val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+			.setContentTitle(context.getString(R.string.google_drive_sync))
+			.setContentText("Re-authentication required")
+			.setSmallIcon(R.drawable.ic_sync)
+			.setAutoCancel(true)
+			.setPriority(NotificationCompat.PRIORITY_HIGH)
+			.build()
+		try {
+			NotificationManagerCompat.from(context).notify(REAUTH_NOTIFICATION_ID, notification)
+		} catch (e: SecurityException) {
+			// Ignore if notification permission is missing
 		}
 	}
 
@@ -112,6 +133,7 @@ class SyncWorker @AssistedInject constructor(
 
 		const val CHANNEL_ID = "sync_status"
 		private const val FOREGROUND_NOTIFICATION_ID = 45
+		private const val REAUTH_NOTIFICATION_ID = 46
 		private const val TAG_PERIODIC = "gdrive_sync_periodic"
 		private const val TAG_MANUAL = "gdrive_sync_manual"
 		private const val MAX_ATTEMPTS = 3

--- a/app/src/main/res/layout/activity_app_update.xml
+++ b/app/src/main/res/layout/activity_app_update.xml
@@ -111,12 +111,19 @@
 
 			<com.google.android.material.button.MaterialButton
 				android:id="@+id/button_update"
+				style="?attr/materialButtonStyle"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_gravity="center_vertical|end"
 				android:enabled="false"
+				android:text="@string/update"
+				android:textColor="?attr/colorOnPrimary"
+				app:backgroundTint="?attr/colorPrimary"
 				app:icon="@drawable/ic_download"
-				android:text="@string/update" />
+				app:iconGravity="textStart"
+				app:iconPadding="8dp"
+				app:iconTint="?attr/colorOnPrimary"
+				app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Kotatsu.Circle" />
 
 		</FrameLayout>
 	</com.google.android.material.dockedtoolbar.DockedToolbarLayout>

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -3,16 +3,12 @@
 	<string name="url_github" translatable="false">https://github.com/HuzaifaKhalid1311/DropSauce</string>
 	<string name="url_discord_web" translatable="false">https://discord.gg/PTd2bYgz9m</string>
 	<string name="url_dropsauce_website" translatable="false">https://drop-sauce.app/</string>
-	<string name="url_weblate" translatable="false">https://hosted.weblate.org/engage/kotatsu</string>
-	<string name="url_user_manual" translatable="false">https://kotatsu.app/manuals/guides/getting-started/</string>
+	<string name="url_weblate" translatable="false">https://github.com/HuzaifaKhalid1311/DropSauce</string>
+	<string name="url_user_manual" translatable="false">https://github.com/HuzaifaKhalid1311/DropSauce</string>
 	<string name="github_updates_repo" translatable="false">HuzaifaKhalid1311/DropSauce</string>
-	<string name="shikimori_clientId" translatable="false">Mw6F0tPEOgyV7F9U9Twg50Q8SndMY7hzIOfXg0AX_XU</string>
-	<string name="shikimori_clientSecret" translatable="false">euBMt1GGRSDpVIFQVPxZrO7Kh6X4gWyv0dABuj4B-M8</string>
-	<string name="anilist_clientId" translatable="false">9887</string>
-	<string name="anilist_clientSecret" translatable="false">wrMqFosItQWsmB8dtAHfIFPDt15FfQi2ZGiKkJoW</string>
 	<string name="mal_clientId" translatable="false">6cd8e6349e9a36bc1fc1ab97703c9fd1</string>
 	<string name="discord_app_id" translatable="false">1444242650067894303</string>
-	<string name="app_icon_url" translatable="false">https://raw.githubusercontent.com/YakaTeam/artifacts/refs/heads/main/.github/assets/icon.png</string>
+	<string name="app_icon_url" translatable="false">https://raw.githubusercontent.com/HuzaifaKhalid1311/DropSauce/main/assets/app-icon-dark.svg</string>
 	<string-array name="values_theme" translatable="false">
 		<item>-1</item>
 		<item>1</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,7 +395,7 @@
     <string name="mark_as_current">Mark as current</string>
     <string name="language">Language</string>
     <string name="theme_name_dynamic">Dynamic</string>
-    <string name="theme_name_expressive">Expressive (Test)</string>
+    <string name="theme_name_expressive">Expressive</string>
     <string name="color_theme">Color scheme</string>
     <string name="show_in_grid_view">Show in grid view</string>
     <string name="theme_name_miku">Miku</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -15,4 +15,21 @@
 				tools:ignore="AcceptsUserCertificates" />
 		</trust-anchors>
 	</base-config>
+
+	<!-- Secure default config for auth/update/sync domains -->
+	<domain-config cleartextTrafficPermitted="false">
+		<domain includeSubdomains="true">shikimori.one</domain>
+		<domain includeSubdomains="true">shikimori.me</domain>
+		<domain includeSubdomains="true">anilist.co</domain>
+		<domain includeSubdomains="true">myanimelist.net</domain>
+		<domain includeSubdomains="true">github.com</domain>
+		<domain includeSubdomains="true">githubusercontent.com</domain>
+		<domain includeSubdomains="true">googleapis.com</domain>
+		<domain includeSubdomains="true">google.com</domain>
+		<domain includeSubdomains="true">discord.com</domain>
+		<domain includeSubdomains="true">drop-sauce.app</domain>
+		<trust-anchors>
+			<certificates src="system" />
+		</trust-anchors>
+	</domain-config>
 </network-security-config>


### PR DESCRIPTION
Implements the pre-release audit fixes and a supervisory review pass. **Builds green** (`assembleDebug`), **unit tests pass** (`testDebugUnitTest`), and the debug APK was installed & smoke-checked on device.

## What's in here
- **Data & migration:** language-independent + 64-bit Mihon ids; scrobbling `updated_at` column (DB **migration 30→31**); MigrateUseCase now carries bookmarks, preserves reading %, guards empty chapters, won't clobber existing favourites; backup restore no longer resurrects deleted history / overwrites newer progress; Mihon restore dedups category & won't wipe chapters.
- **Google Drive sync:** If-Match etag (no lost concurrent writes), streaming encode/decode (no OOM), pagination, per-section tombstone GC (deletions propagate), orphan-favourite skip, settings allowlist, re-auth notification.
- **Reader:** thread-safe PageLoader/ChaptersLoader, full `loadingMutex` coverage, per-holder coroutine scopes (no leaks), zero-size `onReady` guard, `onTrimMemory` bitmap release, `Locale.ROOT` filenames.
- **Settings/details:** search first-keystroke + back-stack + key-based highlight; source active-language switch now applies; details error+retry state instead of infinite spinner.
- **Security/release:** `targetSdk 35`, `allowBackup=false`, OAuth secrets via `buildConfigField`, scoped+debug-only SSL bypass, secure `domain-config` for auth hosts, `drop-sauce.app` deep links, removed `MANAGE_EXTERNAL_STORAGE`, manifest host dedup.

## Supervisor corrections (on top of the original fixes)
- Re-parented `PageViewModel` scope to `loaderScope` (the bare `Job()` leaked on reader teardown).
- Completed `loadingMutex` coverage in `loadPrevNextChapter` (the Critical reader race was only half-fixed).
- Reverted `compileSdk` to the working `release(37)` block DSL (the flattened `= 37` may not resolve `android-37.0` on AGP 9.2.1).

## ⚠️ Open decisions before merge/release
1. **OAuth secrets are still committed** as `build.gradle` fallback defaults — only move to `local.properties`/CI; decide whether to scrub the fallbacks.
2. **`MANAGE_EXTERNAL_STORAGE` removed but its feature code remains** (`LocalStorageManager`, storage-manager permission contract) — either restore the permission (+ Play declaration) or finish removing the custom-storage feature.
3. **Mihon id change has no data-carryover migration** — pre-existing Mihon favourites can detach when re-encountered via search (narrow; non-issue for fresh installs).
4. **Minor:** scrobbler network calls still inside the migrate DB transaction; `app_icon_url` points to an SVG (Discord RPC wants raster); a corrupt *duplicate* remote sync file aborts the whole sync.

## Note
Branch base is 1 commit behind `main` (`d365040` "major code cleanup") — merge `main` in before/at merge time to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)