### PR TITLE
UI fixes: onboarding performance, search gap, settings icon dedup

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/welcome/OnboardingScreen.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/welcome/OnboardingScreen.kt
@@ -45,7 +45,9 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -101,11 +103,11 @@ fun OnboardingScreen(
 ) {
     val pagerState = rememberPagerState(pageCount = { PAGE_COUNT })
     val scope = rememberCoroutineScope()
-    val currentPage = pagerState.currentPage
-    val isLastPage = currentPage == PAGE_COUNT - 1
+    val isLastPage by remember { derivedStateOf { pagerState.currentPage == PAGE_COUNT - 1 } }
+    val backEnabled by remember { derivedStateOf { pagerState.currentPage > 0 } }
 
-    BackHandler(enabled = currentPage > 0) {
-        scope.launch { pagerState.animateScrollToPage(currentPage - 1) }
+    BackHandler(enabled = backEnabled) {
+        scope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -198,7 +200,7 @@ fun OnboardingScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 repeat(PAGE_COUNT) { index ->
-                    val isSelected = index == currentPage
+                    val isSelected by remember(index) { derivedStateOf { index == pagerState.currentPage } }
                     val dotWidth by animateDpAsState(
                         targetValue = if (isSelected) 24.dp else 8.dp,
                         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
@@ -222,7 +224,7 @@ fun OnboardingScreen(
                     if (isLastPage) {
                         actions.onFinish()
                     } else {
-                        scope.launch { pagerState.animateScrollToPage(currentPage + 1) }
+                        scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
                     }
                 },
                 containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
@@ -397,8 +397,8 @@ private fun AppearanceScreen(
 						title = stringResource(R.string.show_reading_indicators),
 						checked = readingIndicator,
 						onCheckedChange = { readingIndicator = it },
-						icon = R.drawable.ic_read,
-						
+						icon = R.drawable.ic_history,
+
 						shape = pos.shape,
 					)
 				}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
@@ -337,8 +337,8 @@ private fun ReaderScreen(
 						subtitle = stringResource(R.string.reader_optimize_summary),
 						checked = readerOptimize,
 						onCheckedChange = { readerOptimize = it },
-						icon = R.drawable.ic_auto_fix,
-						
+						icon = R.drawable.ic_filter_funnel,
+
 						shape = pos.shape,
 					)
 				}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/tracker/TrackerSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/tracker/TrackerSettingsFragment.kt
@@ -297,8 +297,8 @@ private fun TrackerScreen(
 				item { pos ->
 					NavigationSettingsItem(
 						title = stringResource(R.string.notifications),
-						icon = R.drawable.ic_notification,
-						
+						icon = R.drawable.ic_list_detailed,
+
 						shape = pos.shape,
 						enabled = enabled,
 						onClick = onOpenLegacyNotifications,

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,7 +56,7 @@
 			android:gravity="center_vertical"
 			android:clipToPadding="false"
 			android:paddingHorizontal="4dp"
-			android:paddingBottom="10dp"
+			android:paddingBottom="4dp"
 			app:layout_scrollFlags="scroll|enterAlways|snap">
 
 			<FrameLayout


### PR DESCRIPTION
## Summary

- **Onboarding lag**: Replaced top-level `pagerState.currentPage` read in `OnboardingScreen` with `derivedStateOf` — the entire screen was recomposing on every animation frame during page transitions; now only the 4 dot indicators recompose per frame
- **Search → favorites gap**: Reduced `paddingBottom` on the search bar container in `activity_main.xml` from 10 dp to 4 dp, tightening the visual gap between the search bar and the favorites category tabs
- **Settings icon deduplication**: Three settings screens had an icon used on two different options in the same screen:
  - Appearance: `ic_read` was on both "Show reading indicators" (→ `ic_history`) and "Show floating continue button" (kept `ic_read`)
  - Reader: `ic_auto_fix` was on both "Detect reader mode" (kept) and "Reader optimize" (→ `ic_filter_funnel`)
  - Tracker: `ic_notification` was on both "Notifications settings" (kept) and "Notifications" legacy (→ `ic_list_detailed`)

## Test plan

- [ ] Fresh-install the app and swipe through all 4 onboarding pages — transitions should be smooth at 60+ fps
- [ ] Open the Favourites tab and confirm the gap between the search bar and the category tabs is visibly tighter
- [ ] Open Settings → Appearance, Reader, and Tracker and confirm no two options in the same screen share the same icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)