### PR TITLE
Fix Mihon filter input alignment

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/filter/ui/mihon/MihonFilterAdapter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/filter/ui/mihon/MihonFilterAdapter.kt
@@ -65,6 +65,13 @@ private fun View.applyMarginIndent(depth: Int) {
 	}
 }
 
+private fun View.applyInputPaddingIndent(depth: Int) {
+	val step = (INDENT_DP * resources.displayMetrics.density).toInt()
+	val base = resources.getDimensionPixelOffset(R.dimen.margin_normal)
+	val inset = base + depth * step
+	updatePaddingRelative(start = inset, end = inset)
+}
+
 private fun headerDelegate() =
 	adapterDelegateViewBinding<MihonFilterItem.Header, MihonFilterItem, ItemFilterHeaderBinding>(
 		{ inflater, parent -> ItemFilterHeaderBinding.inflate(inflater, parent, false) },
@@ -158,7 +165,7 @@ private fun textDelegate(listener: MihonFilterListener) =
 			if (binding.editText.text?.toString() != item.value) {
 				binding.editText.setText(item.value)
 			}
-			binding.layoutInput.applyMarginIndent(item.depth)
+			binding.root.applyInputPaddingIndent(item.depth)
 		}
 	}
 
@@ -176,7 +183,7 @@ private fun selectDelegate(listener: MihonFilterListener) =
 			)
 			val selected = item.options.getOrNull(item.selectedIndex).orEmpty()
 			binding.editSelect.setText(selected, false)
-			binding.layoutInput.applyMarginIndent(item.depth)
+			binding.root.applyInputPaddingIndent(item.depth)
 		}
 	}
 

--- a/app/src/main/res/layout/item_filter_select.xml
+++ b/app/src/main/res/layout/item_filter_select.xml
@@ -1,23 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.textfield.TextInputLayout
+<LinearLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools"
-	android:id="@+id/layout_input"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	android:layout_marginHorizontal="@dimen/margin_normal"
-	android:layout_marginVertical="@dimen/margin_small"
-	app:endIconMode="dropdown_menu"
-	tools:hint="Status">
+	android:orientation="vertical"
+	android:paddingHorizontal="@dimen/margin_normal"
+	android:paddingVertical="@dimen/margin_small">
 
-	<com.google.android.material.textfield.MaterialAutoCompleteTextView
-		android:id="@+id/edit_select"
-		style="?editTextStyle"
+	<com.google.android.material.textfield.TextInputLayout
+		android:id="@+id/layout_input"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:inputType="none"
-		android:popupBackground="@drawable/m3_spinner_popup_background"
-		tools:ignore="LabelFor" />
+		app:endIconMode="dropdown_menu"
+		tools:hint="Status">
 
-</com.google.android.material.textfield.TextInputLayout>
+		<com.google.android.material.textfield.MaterialAutoCompleteTextView
+			android:id="@+id/edit_select"
+			style="?editTextStyle"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:inputType="none"
+			android:popupBackground="@drawable/m3_spinner_popup_background"
+			tools:ignore="LabelFor" />
+
+	</com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_filter_text.xml
+++ b/app/src/main/res/layout/item_filter_text.xml
@@ -1,20 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.textfield.TextInputLayout
+<LinearLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
-	android:id="@+id/layout_input"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	android:layout_marginHorizontal="@dimen/margin_normal"
-	android:layout_marginVertical="@dimen/margin_small"
-	tools:hint="Author">
+	android:orientation="vertical"
+	android:paddingHorizontal="@dimen/margin_normal"
+	android:paddingVertical="@dimen/margin_small">
 
-	<com.google.android.material.textfield.TextInputEditText
-		android:id="@+id/edit_text"
+	<com.google.android.material.textfield.TextInputLayout
+		android:id="@+id/layout_input"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:imeOptions="actionDone"
-		android:inputType="text"
-		android:maxLines="1" />
+		tools:hint="Author">
 
-</com.google.android.material.textfield.TextInputLayout>
+		<com.google.android.material.textfield.TextInputEditText
+			android:id="@+id/edit_text"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:imeOptions="actionDone"
+			android:inputType="text"
+			android:maxLines="1" />
+
+	</com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- keep Mihon extension text and select filter fields inset on both sides
- preserve nested filter indentation while shortening the right edge for balanced input boxes

## Testing
- Not run; existing local working tree contains unrelated staged changes.