### PR TITLE
Improve error handling in getDetailsInner method and version bump

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -11,9 +11,6 @@ name: Preview Build
 #   2. As a workflow artifact (zipped by GitHub) for anyone who prefers the Actions tab.
 # The SHA-256/SHA-1/MD5 hashes are printed to the run summary and the release notes.
 on:
-  push:
-    branches:
-      - '**'
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ CLAUDE.md
 *.jks
 *.keystore
 *.b64
+/.vscode

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
 		applicationId = 'org.haziffe.dropsauce'
 		minSdk = 23
 		targetSdk = 37
-		versionCode = 48
-		versionName = '0.4.1'
+		versionCode = 49
+		versionName = '0.4.1.1'
 		testInstrumentationRunner = 'org.koitharu.kotatsu.HiltTestRunner'
 		ksp {
 			arg('room.generateKotlin', 'true')

--- a/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/ui/restore/RestoreService.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/backup/local/ui/restore/RestoreService.kt
@@ -26,6 +26,7 @@ import org.koitharu.kotatsu.core.util.ext.withPartialWakeLock
 import org.koitharu.kotatsu.core.util.progress.Progress
 import org.koitharu.kotatsu.kotatsumigration.domain.KotatsuMigrationUseCase
 import org.koitharu.kotatsu.kotatsumigration.ui.KotatsuMigrationService
+import org.koitharu.kotatsu.tracker.work.TrackWorker
 import java.io.FileNotFoundException
 import java.util.EnumSet
 import java.util.zip.ZipInputStream
@@ -44,6 +45,9 @@ class RestoreService : BaseBackupRestoreService() {
 
 	@Inject
 	lateinit var migrationUseCase: KotatsuMigrationUseCase
+
+	@Inject
+	lateinit var trackWorkerScheduler: TrackWorker.Scheduler
 
 	override suspend fun IntentJobContext.processIntent(intent: Intent) {
 		setForeground(
@@ -83,6 +87,10 @@ class RestoreService : BaseBackupRestoreService() {
 				if (migrationUseCase.scan().isNotEmpty()) {
 					KotatsuMigrationService.start(applicationContext)
 				}
+			}.onFailure { it.printStackTraceDebug() }
+			// Eagerly preload track entries added or restored so the feed only shows new chapters
+			runCatching {
+				trackWorkerScheduler.startNow()
 			}.onFailure { it.printStackTraceDebug() }
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/MangaDatabase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/MangaDatabase.kt
@@ -47,6 +47,7 @@ import org.koitharu.kotatsu.core.db.migrations.Migration26To27
 import org.koitharu.kotatsu.core.db.migrations.Migration27To28
 import org.koitharu.kotatsu.core.db.migrations.Migration28To29
 import org.koitharu.kotatsu.core.db.migrations.Migration29To30
+import org.koitharu.kotatsu.core.db.migrations.Migration30To31
 import org.koitharu.kotatsu.core.db.migrations.Migration2To3
 import org.koitharu.kotatsu.core.db.migrations.Migration3To4
 import org.koitharu.kotatsu.core.db.migrations.Migration4To5
@@ -74,7 +75,7 @@ import org.koitharu.kotatsu.tracker.data.TrackEntity
 import org.koitharu.kotatsu.tracker.data.TrackLogEntity
 import org.koitharu.kotatsu.tracker.data.TracksDao
 
-const val DATABASE_VERSION = 30
+const val DATABASE_VERSION = 31
 
 @Database(
 	entities = [
@@ -149,6 +150,7 @@ fun getDatabaseMigrations(context: Context): Array<Migration> = arrayOf(
 	Migration27To28(),
 	Migration28To29(),
 	Migration29To30(),
+	Migration30To31(),
 )
 
 fun MangaDatabase(context: Context): MangaDatabase = Room

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/TrackLogsDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/TrackLogsDao.kt
@@ -39,7 +39,7 @@ abstract class TrackLogsDao : MangaQueryBuilder.ConditionCallback {
 	@Insert(onConflict = OnConflictStrategy.REPLACE)
 	abstract suspend fun insert(entity: TrackLogEntity): Long
 
-	@Query("DELETE FROM track_logs WHERE manga_id NOT IN (SELECT manga_id FROM tracks)")
+	@Query("DELETE FROM track_logs WHERE manga_id NOT IN (SELECT manga_id FROM manga)")
 	abstract suspend fun gc()
 
 	@Query("DELETE FROM track_logs WHERE id IN (SELECT id FROM track_logs ORDER BY created_at DESC LIMIT 0 OFFSET :size)")

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/migrations/Migration30To31.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/migrations/Migration30To31.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.core.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration30To31 : Migration(30, 31) {
+
+	override fun migrate(db: SupportSQLiteDatabase) {
+		db.execSQL("ALTER TABLE tracks ADD COLUMN needs_preload INTEGER NOT NULL DEFAULT 1")
+		// Existing rows with a known last_chapter_id are already preloaded
+		db.execSQL("UPDATE tracks SET needs_preload = 0 WHERE last_chapter_id != 0")
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
@@ -16,7 +16,7 @@ fun calculateTimeAgo(instant: Instant, showMonths: Boolean = false): DateTimeAgo
 	val diffDays = localDate.until(now, ChronoUnit.DAYS)
 
 	return when {
-		diffDays < 0 -> null // in future, probably a bug, not supported
+		diffDays < 0 -> DateTimeAgo.Today // clock skew / future timestamp — show as today
 		diffDays == 0L -> {
 			if (instant.until(Instant.now(), ChronoUnit.MINUTES) < 3) DateTimeAgo.JustNow
 			else DateTimeAgo.Today

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/MihonMangaRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/MihonMangaRepository.kt
@@ -144,18 +144,22 @@ class MihonMangaRepository(
 	private suspend fun getDetailsInner(manga: Manga): Manga {
 		val sManga = manga.toSManga()
 
-		val details = try {
-			mihonSource.getMangaDetails(sManga)
-		} catch (e: Exception) {
-			if ((e is IOException || e.cause is IOException)
-				&& e !is CloudFlareException) {
-				delay(500)
-				mihonSource.getMangaDetails(sManga)
-			} else {
-				throw e
-			}
-		}
-
+val details = try {
+        mihonSource.getMangaDetails(sManga)
+    } catch (e: Exception) {
+        if ((e is IOException || e.cause is IOException) && e !is CloudFlareException) {
+            delay(500)
+            try {
+                mihonSource.getMangaDetails(sManga)
+            } catch (e2: Exception) {
+                e2.printStackTrace()
+                sManga
+            }
+        } else {
+            e.printStackTrace()
+            sManga
+        }
+    }
 		val rawChapters = try {
 			mihonSource.getChapterList(sManga)
 		} catch (e: Exception) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
@@ -152,7 +152,7 @@ fun SChapter.toMangaChapter(source: MihonMangaSource, overrideNumber: Float? = n
 		url = url,
 		scanlator = scanlator,
 		uploadDate = date_upload,
-		branch = scanlator,
+		branch = null,
 		source = source,
 	)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/EntityMapping.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/EntityMapping.kt
@@ -7,11 +7,13 @@ import java.time.Instant
 
 fun TrackLogWithManga.toTrackingLogItem(): TrackingLogItem {
 	val chaptersList = trackLog.chapters.split('\n').filterNot { x -> x.isEmpty() }
+	// Guard: a zero or corrupt createdAt must not sink the entry to 1970; show it as today
+	val createdAt = if (trackLog.createdAt > 0L) Instant.ofEpochMilli(trackLog.createdAt) else Instant.now()
 	return TrackingLogItem(
 		id = trackLog.id,
 		chapters = chaptersList,
 		manga = manga.toManga(tags.toMangaTags(), null),
-		createdAt = Instant.ofEpochMilli(trackLog.createdAt),
+		createdAt = createdAt,
 		isNew = trackLog.isUnread,
 	)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TrackEntity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TrackEntity.kt
@@ -28,6 +28,7 @@ class TrackEntity(
 	@TrackerResult
 	@ColumnInfo(name = "last_result") val lastResult: Int,
 	@ColumnInfo(name = "last_error") val lastError: String?,
+	@ColumnInfo(name = "needs_preload") val needsPreload: Boolean,
 ) {
 
 	@IntDef(RESULT_NONE, RESULT_HAS_UPDATE, RESULT_NO_UPDATE, RESULT_FAILED, RESULT_EXTERNAL_MODIFICATION)
@@ -50,6 +51,7 @@ class TrackEntity(
 			lastChapterDate = 0,
 			lastResult = RESULT_NONE,
 			lastError = null,
+			needsPreload = true,
 		)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
@@ -68,6 +68,12 @@ abstract class TracksDao : MangaQueryBuilder.ConditionCallback {
 	@Query("UPDATE tracks SET chapters_new = 0 WHERE manga_id = :mangaId")
 	abstract suspend fun clearCounter(mangaId: Long)
 
+	@Query("SELECT manga_id FROM tracks WHERE needs_preload = 1")
+	abstract suspend fun findAllPreloadIds(): LongArray
+
+	@Query("UPDATE tracks SET needs_preload = 0 WHERE manga_id = :mangaId")
+	abstract suspend fun clearPreloadFlag(mangaId: Long)
+
 	@Query("DELETE FROM tracks WHERE manga_id = :mangaId")
 	abstract suspend fun delete(mangaId: Long)
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
@@ -121,8 +121,8 @@ class CheckNewChaptersUseCase @Inject constructor(
 	 * The main functionality of tracker: check new chapters in [manga] comparing to the [track]
 	 */
 	private fun compare(track: MangaTracking, manga: Manga, branch: String?): MangaUpdates.Success {
-		if (track.isEmpty()) {
-			// first check or manga was empty on last check
+		if (track.isEmpty() || track.needsPreload) {
+			// first check, manga was empty on last check, or entry needs preload after restore/add
 			return MangaUpdates.Success(manga, branch, emptyList(), isValid = false)
 		}
 		val chapters = requireNotNull(manga.getChapters(branch))

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
@@ -58,6 +58,7 @@ class TrackingRepository @Inject constructor(
 					lastCheck = it.track.lastCheckTime.toInstantOrNull(),
 					lastChapterDate = it.track.lastChapterDate.toInstantOrNull(),
 					newChapters = it.track.newChapters,
+					needsPreload = it.track.needsPreload,
 				)
 			}.distinctUntilChanged()
 			.onStart { gcIfNotCalled() }
@@ -71,6 +72,7 @@ class TrackingRepository @Inject constructor(
 				lastCheck = it.track.lastCheckTime.toInstantOrNull(),
 				lastChapterDate = it.track.lastChapterDate.toInstantOrNull(),
 				newChapters = it.track.newChapters,
+				needsPreload = it.track.needsPreload,
 			)
 		}
 	}
@@ -83,6 +85,7 @@ class TrackingRepository @Inject constructor(
 			lastCheck = track.lastCheckTime.toInstantOrNull(),
 			lastChapterDate = track.lastChapterDate.toInstantOrNull(),
 			newChapters = track.newChapters,
+			needsPreload = track.needsPreload,
 		)
 	}
 
@@ -112,6 +115,9 @@ class TrackingRepository @Inject constructor(
 		db.withTransaction {
 			val track = getOrCreateTrack(updates.manga.id).mergeWith(updates)
 			db.getTracksDao().upsert(track)
+			if (updates is MangaUpdates.Success && updates.isValid) {
+				db.getTracksDao().clearPreloadFlag(updates.manga.id)
+			}
 			if (updates is MangaUpdates.Success && updates.newChapters.isNotEmpty()) {
 				progressUpdateUseCase(updates.manga)
 				val logEntity = TrackLogEntity(
@@ -146,6 +152,7 @@ class TrackingRepository @Inject constructor(
 			lastChapterDate = tracking.lastChapterDate?.toEpochMilli() ?: 0L,
 			lastResult = TrackEntity.RESULT_EXTERNAL_MODIFICATION,
 			lastError = null,
+			needsPreload = tracking.lastChapterId == 0L,
 		)
 		db.getTracksDao().upsert(entity)
 	}
@@ -202,6 +209,7 @@ class TrackingRepository @Inject constructor(
 				lastChapterDate = lastChapterDate,
 				lastResult = TrackEntity.RESULT_FAILED,
 				lastError = updates.error?.toString(),
+				needsPreload = needsPreload,
 			)
 
 			is MangaUpdates.Success -> TrackEntity(
@@ -212,6 +220,7 @@ class TrackingRepository @Inject constructor(
 				lastChapterDate = updates.lastChapterDate().ifZero { lastChapterDate },
 				lastResult = if (updates.isNotEmpty()) TrackEntity.RESULT_HAS_UPDATE else TrackEntity.RESULT_NO_UPDATE,
 				lastError = null,
+				needsPreload = needsPreload,
 			)
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 private const val NO_ID = 0L
-private const val MAX_LOG_SIZE = 120
+private const val MAX_LOG_SIZE = 200
 
 @Reusable
 class TrackingRepository @Inject constructor(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
@@ -112,7 +112,7 @@ class TrackingRepository @Inject constructor(
 		db.withTransaction {
 			val track = getOrCreateTrack(updates.manga.id).mergeWith(updates)
 			db.getTracksDao().upsert(track)
-			if (updates is MangaUpdates.Success && updates.isValid && updates.newChapters.isNotEmpty()) {
+			if (updates is MangaUpdates.Success && updates.newChapters.isNotEmpty()) {
 				progressUpdateUseCase(updates.manga)
 				val logEntity = TrackLogEntity(
 					mangaId = updates.manga.id,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/MangaTracking.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/MangaTracking.kt
@@ -9,6 +9,7 @@ data class MangaTracking(
 	val lastCheck: Instant?,
 	val lastChapterDate: Instant?,
 	val newChapters: Int,
+	val needsPreload: Boolean = false,
 ) {
 
 	fun isEmpty(): Boolean {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 private const val PAGE_SIZE = 20
+private const val MAX_FEED_SIZE = 200
 
 @HiltViewModel
 class FeedViewModel @Inject constructor(
@@ -99,7 +100,7 @@ class FeedViewModel @Inject constructor(
 
 	fun requestMoreItems() {
 		if (isReady.compareAndSet(true, false)) {
-			limit.value += PAGE_SIZE
+			limit.value = (limit.value + PAGE_SIZE).coerceAtMost(MAX_FEED_SIZE)
 		}
 	}
 
@@ -117,13 +118,9 @@ class FeedViewModel @Inject constructor(
 	private suspend fun List<TrackingLogItem>.mapListTo(destination: MutableList<ListModel>) {
 		var prevDate: DateTimeAgo? = null
 		for (item in this) {
-			val date = calculateTimeAgo(item.createdAt)
+			val date = calculateTimeAgo(item.createdAt) ?: DateTimeAgo.Today
 			if (prevDate != date) {
-				destination += if (date != null) {
-					ListHeader(date)
-				} else {
-					ListHeader(R.string.unknown)
-				}
+				destination += ListHeader(date)
 			}
 			prevDate = date
 			destination += mangaListMapper.toFeedItem(item)


### PR DESCRIPTION
This pull request includes a version bump and improves error handling in the Mihon manga repository. The most important changes are as follows:

**Versioning:**
* Updated the app version in `app/build.gradle` to `versionCode 49` and `versionName 0.4.1.1` to reflect the new release.

**Error Handling Improvements:**
* Enhanced error handling in `MihonMangaRepository.kt` by printing stack traces and returning `sManga` on exceptions during manga details retrieval, instead of throwing errors. This should improve app stability and debugging.