### PR TITLE
Add verbose logging and fix Mihon feed detection

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/logs/AppLogger.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/logs/AppLogger.kt
@@ -1,0 +1,119 @@
+package org.koitharu.kotatsu.core.logs
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.concurrent.ArrayBlockingQueue
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val MAX_ENTRIES = 4000
+
+@Singleton
+class AppLogger @Inject constructor() {
+
+	@Volatile
+	var isEnabled: Boolean = false
+		private set
+
+	private val buffer = ArrayBlockingQueue<String>(MAX_ENTRIES)
+	private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+	private val stateLock = Any()
+	private var readerJob: Job? = null
+	private var logcatProcess: Process? = null
+	private var generation = 0
+
+	fun setEnabled(enabled: Boolean) {
+		synchronized(stateLock) {
+			if (enabled == isEnabled) return
+			isEnabled = enabled
+			generation++
+			if (enabled) {
+				buffer.clear()
+				startReadingLocked(generation)
+			} else {
+				stopReadingLocked()
+			}
+		}
+	}
+
+	suspend fun stopAndDrainToString(): String {
+		val job = synchronized(stateLock) {
+			if (isEnabled) {
+				isEnabled = false
+				generation++
+			}
+			stopReadingLocked()
+		}
+		job?.join()
+		return drainToString()
+	}
+
+	private fun drainToString(): String {
+		val lines = ArrayList<String>(buffer.size)
+		buffer.drainTo(lines)
+		return lines.joinToString("\n")
+	}
+
+	private fun startReadingLocked(readerGeneration: Int) {
+		val job = scope.launch(start = CoroutineStart.LAZY) {
+			var process: Process? = null
+			try {
+				Runtime.getRuntime().exec(arrayOf("logcat", "-c")).waitFor()
+				val pid = android.os.Process.myPid().toString()
+				val startedProcess = Runtime.getRuntime().exec(arrayOf("logcat", "-v", "time", "--pid", pid))
+				process = startedProcess
+				synchronized(stateLock) {
+					if (!isEnabled || generation != readerGeneration) {
+						startedProcess.destroy()
+						return@launch
+					}
+					logcatProcess = startedProcess
+				}
+				BufferedReader(InputStreamReader(startedProcess.inputStream)).use { reader ->
+					while (isActive) {
+						val line = reader.readLine() ?: break
+						if (!buffer.offer(line)) {
+							buffer.poll()
+							buffer.offer(line)
+						}
+					}
+				}
+			} catch (e: CancellationException) {
+				throw e
+			} catch (e: Exception) {
+				Log.e("AppLogger", "Failed to read logcat", e)
+			} finally {
+				process?.destroy()
+				synchronized(stateLock) {
+					if (generation == readerGeneration) {
+						logcatProcess = null
+						readerJob = null
+					}
+				}
+			}
+		}
+		readerJob = job
+		job.start()
+	}
+
+	private fun stopReadingLocked(): Job? {
+		val job = readerJob
+		readerJob = null
+		job?.cancel()
+		logcatProcess?.let { process ->
+			runCatching { process.inputStream.close() }
+			process.destroy()
+		}
+		logcatProcess = null
+		return job
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -707,6 +707,10 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		get() = prefs.getString(KEY_DISCORD_TOKEN, null)?.trim()?.nullIfEmpty()
 		set(value) = prefs.edit { putString(KEY_DISCORD_TOKEN, value?.nullIfEmpty()) }
 
+	var isVerboseLoggingEnabled: Boolean
+		get() = prefs.getBoolean(KEY_VERBOSE_LOGGING, false)
+		set(value) = prefs.edit { putBoolean(KEY_VERBOSE_LOGGING, value) }
+
 	val isReadingTimeEstimationEnabled: Boolean
 		get() = prefs.getBoolean(KEY_READING_TIME, true)
 
@@ -977,6 +981,7 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_DETAILS_LAST_TAB = "details_last_tab"
 		const val KEY_DETAILS_BACKDROP = "details_backdrop"
 		const val KEY_DETAILS_BACKDROP_BLUR_AMOUNT = "details_backdrop_blur_amount"
+		const val KEY_VERBOSE_LOGGING = "verbose_logging"
 		const val KEY_READING_TIME = "reading_time"
 		const val KEY_PAGES_SAVE_DIR = "pages_dir"
 		const val KEY_PAGES_SAVE_ASK = "pages_dir_ask"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/mihon/model/MihonDataConverters.kt
@@ -152,7 +152,7 @@ fun SChapter.toMangaChapter(source: MihonMangaSource, overrideNumber: Float? = n
 		url = url,
 		scanlator = scanlator,
 		uploadDate = date_upload,
-		branch = scanlator,
+		branch = null,
 		source = source,
 	)
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/AboutSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/AboutSettingsFragment.kt
@@ -1,10 +1,12 @@
 package org.koitharu.kotatsu.settings.about
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -70,11 +72,29 @@ import org.koitharu.kotatsu.settings.compose.BaseComposeSettingsFragment
 import org.koitharu.kotatsu.settings.compose.DropSauceTheme
 import org.koitharu.kotatsu.settings.compose.SettingsGroup
 import org.koitharu.kotatsu.settings.compose.SettingsScaffold
+import org.koitharu.kotatsu.settings.compose.SwitchSettingsItem
 
 @AndroidEntryPoint
 class AboutSettingsFragment : BaseComposeSettingsFragment(R.string.about) {
 
 	private val viewModel by viewModels<AboutSettingsViewModel>()
+
+	private var pendingLogContent: String? = null
+
+	private val saveLogLauncher = registerForActivityResult(
+		ActivityResultContracts.CreateDocument("text/plain"),
+	) { uri: Uri? ->
+		val content = pendingLogContent ?: return@registerForActivityResult
+		pendingLogContent = null
+		if (uri == null) return@registerForActivityResult
+		try {
+			requireContext().contentResolver.openOutputStream(uri)?.use { output ->
+				output.write(content.toByteArray(Charsets.UTF_8))
+			}
+		} catch (_: Exception) {
+			Snackbar.make(requireView(), R.string.error_occurred, Snackbar.LENGTH_SHORT).show()
+		}
+	}
 
 	override fun onCreateView(
 		inflater: LayoutInflater,
@@ -86,13 +106,16 @@ class AboutSettingsFragment : BaseComposeSettingsFragment(R.string.about) {
 			DropSauceTheme {
 				val isUpdateSupported by viewModel.isUpdateSupported.collectAsState()
 				val isLoading by viewModel.isLoading.collectAsState()
+				val isVerboseLogging by viewModel.isVerboseLogging.collectAsState()
 				AboutScreen(
 					appVersion = BuildConfig.VERSION_NAME,
 					checkUpdatesEnabled = isUpdateSupported && !isLoading,
+					isVerboseLogging = isVerboseLogging,
 					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
 					onCheckUpdates = viewModel::checkForUpdates,
 					onChangelog = ::openChangelog,
 					onOpenLink = ::openLink,
+					onVerboseLoggingToggle = viewModel::setVerboseLogging,
 				)
 			}
 		}
@@ -101,6 +124,10 @@ class AboutSettingsFragment : BaseComposeSettingsFragment(R.string.about) {
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		super.onViewCreated(view, savedInstanceState)
 		viewModel.onUpdateAvailable.observeEvent(viewLifecycleOwner, ::onUpdateAvailable)
+		viewModel.onExportLog.observeEvent(viewLifecycleOwner) { content ->
+			pendingLogContent = content
+			saveLogLauncher.launch("dropsauce_log_${System.currentTimeMillis()}.txt")
+		}
 	}
 
 	private fun openChangelog() {
@@ -135,10 +162,12 @@ class AboutSettingsFragment : BaseComposeSettingsFragment(R.string.about) {
 private fun AboutScreen(
 	appVersion: String,
 	checkUpdatesEnabled: Boolean,
+	isVerboseLogging: Boolean,
 	onBack: () -> Unit,
 	onCheckUpdates: () -> Unit,
 	onChangelog: () -> Unit,
 	onOpenLink: (urlRes: Int, titleRes: Int) -> Unit,
+	onVerboseLoggingToggle: (Boolean) -> Unit,
 ) {
 	val ctx = LocalContext.current
 	SettingsScaffold(title = stringResource(R.string.about), onBack = onBack) {
@@ -197,6 +226,25 @@ private fun AboutScreen(
 						icon = R.drawable.ic_discord,
 						shape = pos.shape,
 						onClick = { onOpenLink(R.string.url_discord_web, R.string.discord) },
+					)
+				}
+			}
+		}
+		item { Spacer(Modifier.height(8.dp).fillMaxWidth()) }
+		item {
+			SettingsGroup(title = "Diagnostics") {
+				item { pos ->
+					SwitchSettingsItem(
+						title = "Verbose logging",
+						subtitle = if (isVerboseLogging) {
+							"Recording — turn off to save log as .txt"
+						} else {
+							"Off by default to preserve performance"
+						},
+						icon = R.drawable.ic_script,
+						shape = pos.shape,
+						checked = isVerboseLogging,
+						onCheckedChange = onVerboseLoggingToggle,
 					)
 				}
 			}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/AboutSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/about/AboutSettingsViewModel.kt
@@ -2,11 +2,16 @@ package org.koitharu.kotatsu.settings.about
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import org.koitharu.kotatsu.core.github.AppUpdateRepository
 import org.koitharu.kotatsu.core.github.AppVersion
+import org.koitharu.kotatsu.core.logs.AppLogger
+import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.core.ui.BaseViewModel
 import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
 import org.koitharu.kotatsu.core.util.ext.call
@@ -15,6 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class AboutSettingsViewModel @Inject constructor(
 	private val appUpdateRepository: AppUpdateRepository,
+	private val settings: AppSettings,
+	private val appLogger: AppLogger,
 ) : BaseViewModel() {
 
 	val isUpdateSupported = flow {
@@ -22,11 +29,36 @@ class AboutSettingsViewModel @Inject constructor(
 	}.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
 	val onUpdateAvailable = MutableEventFlow<AppVersion?>()
+	val onExportLog = MutableEventFlow<String>()
+
+	private val _isVerboseLogging = MutableStateFlow(settings.isVerboseLoggingEnabled)
+	val isVerboseLogging: StateFlow<Boolean> = _isVerboseLogging
+
+	init {
+		if (settings.isVerboseLoggingEnabled) {
+			appLogger.setEnabled(true)
+		}
+	}
 
 	fun checkForUpdates() {
 		launchLoadingJob {
 			val update = appUpdateRepository.fetchUpdate()
 			onUpdateAvailable.call(update)
+		}
+	}
+
+	fun setVerboseLogging(enabled: Boolean) {
+		settings.isVerboseLoggingEnabled = enabled
+		_isVerboseLogging.value = enabled
+		if (enabled) {
+			appLogger.setEnabled(true)
+		} else {
+			launchJob(Dispatchers.Default) {
+				val content = appLogger.stopAndDrainToString()
+				if (content.isNotBlank()) {
+					onExportLog.call(content)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Focused replacement for #100 that keeps only the two required changes:

- add opt-in verbose app logging with safe logcat capture and `.txt` export from Settings → About
- fix Mihon tracker-feed detection by keeping scanlator metadata separate from chapter branching

All database, tracker rebuild, feed download/delete UI, scrobbling UI, workflow, version, and unrelated migration changes from #100 are intentionally excluded.

## Validation

- `:app:testDebugUnitTest`
- `:app:lintDebug`
- `:app:installDebug` on Pixel 9 Pro
- launch verified with a live process and clean crash buffer