### PR TITLE
Implement feed screen view model and chapter tracking for manga updates and inherited entries from backups/migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ CLAUDE.md
 *.jks
 *.keystore
 *.b64
+/.vscode

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/ChaptersDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/db/dao/ChaptersDao.kt
@@ -13,6 +13,9 @@ abstract class ChaptersDao {
 	@Query("SELECT * FROM chapters WHERE manga_id = :mangaId ORDER BY `index` ASC")
 	abstract suspend fun findAll(mangaId: Long): List<ChapterEntity>
 
+	@Query("SELECT COUNT(*) FROM chapters WHERE manga_id = :mangaId")
+	abstract suspend fun getChaptersCount(mangaId: Long): Int
+
 	@Query("DELETE FROM chapters WHERE manga_id = :mangaId")
 	abstract suspend fun deleteAll(mangaId: Long)
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -112,6 +112,23 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 	val onboardingInstallTime: Long
 		get() = runCatching { onboardingInstallIdFile.lastModified() }.getOrDefault(0L)
 
+	val dismissedFeedItems: Set<String>
+		get() = prefs.getStringSet(KEY_DISMISSED_FEED_ITEMS, emptySet()).orEmpty()
+
+	fun dismissFeedItems(mangaIds: Collection<Long>) = synchronized(prefs) {
+		prefs.edit {
+			putStringSet(KEY_DISMISSED_FEED_ITEMS, mangaIds.mapToSet { it.toString() })
+		}
+	}
+
+	fun restoreFeedItem(mangaId: Long) = synchronized(prefs) {
+		val dismissed = dismissedFeedItems
+		val key = mangaId.toString()
+		if (key in dismissed) {
+			prefs.edit { putStringSet(KEY_DISMISSED_FEED_ITEMS, dismissed - key) }
+		}
+	}
+
 	var mainNavItems: List<NavItem>
 		get() {
 			val raw = prefs.getString(KEY_NAV_MAIN, null)?.split(',')
@@ -889,6 +906,7 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_THUMBS_CACHE_CLEAR = "thumbs_cache_clear"
 		const val KEY_SEARCH_HISTORY_CLEAR = "search_history_clear"
 		const val KEY_UPDATES_FEED_CLEAR = "updates_feed_clear"
+		const val KEY_DISMISSED_FEED_ITEMS = "dismissed_feed_items"
 		const val KEY_GRID_SIZE = "grid_size"
 		const val KEY_GRID_SIZE_PAGES = "grid_size_pages"
 		const val KEY_LOCAL_STORAGE = "local_storage"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -109,6 +109,9 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 			}
 		}
 
+	val onboardingInstallTime: Long
+		get() = runCatching { onboardingInstallIdFile.lastModified() }.getOrDefault(0L)
+
 	var mainNavItems: List<NavItem>
 		get() {
 			val raw = prefs.getString(KEY_NAV_MAIN, null)?.split(',')

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Date.kt
@@ -52,3 +52,28 @@ fun Resources.formatDurationShort(millis: Long): String? {
 }
 
 fun LocalDate.toMillis(): Long = atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+fun <T> List<T>.groupByDateBucket(
+	instantOf: (T) -> Instant?,
+	showMonths: Boolean = false,
+): List<Pair<DateTimeAgo?, List<T>>> {
+	if (isEmpty()) {
+		return emptyList()
+	}
+	val grouped = LinkedHashMap<DateTimeAgo?, MutableList<T>>()
+	val latestInstantByGroup = HashMap<DateTimeAgo?, Instant>()
+	for (item in this) {
+		val instant = instantOf(item)
+		val group = instant?.let { calculateTimeAgo(it, showMonths) }
+		grouped.getOrPut(group) { ArrayList() }.add(item)
+		if (instant != null) {
+			val previous = latestInstantByGroup[group]
+			if (previous == null || instant > previous) {
+				latestInstantByGroup[group] = instant
+			}
+		}
+	}
+	return grouped.entries
+		.sortedByDescending { latestInstantByGroup[it.key] ?: Instant.MIN }
+		.map { it.key to it.value }
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListMapper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListMapper.kt
@@ -81,7 +81,7 @@ class MangaListMapper @Inject constructor(
 	suspend fun toFeedItem(logItem: TrackingLogItem) = FeedItem(
 		id = logItem.id,
 		override = dataRepository.getOverride(logItem.manga.id),
-		count = logItem.chapters.size,
+		count = logItem.count,
 		manga = logItem.manga,
 		isNew = logItem.isNew,
 	)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListMapper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/MangaListMapper.kt
@@ -84,6 +84,7 @@ class MangaListMapper @Inject constructor(
 		count = logItem.count,
 		manga = logItem.manga,
 		isNew = logItem.isNew,
+		showTotal = logItem.showTotal,
 	)
 
 	fun mapTags(tags: Collection<MangaTag>) = tags.map {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
@@ -59,6 +59,18 @@ abstract class TracksDao : MangaQueryBuilder.ConditionCallback {
 			.build(),
 	)
 
+	fun observeAllTracks(
+		limit: Int,
+		filterOptions: Set<ListFilterOption>,
+	): Flow<List<MangaWithTrack>> = observeMangaImpl(
+		MangaQueryBuilder("tracks", this)
+			.where("EXISTS(SELECT * FROM favourites WHERE favourites.manga_id = tracks.manga_id AND favourites.deleted_at = 0)")
+			.filters(filterOptions)
+			.limit(limit)
+			.orderBy("last_chapter_date DESC")
+			.build(),
+	)
+
 	@Query("DELETE FROM tracks")
 	abstract suspend fun clear()
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/data/TracksDao.kt
@@ -64,7 +64,6 @@ abstract class TracksDao : MangaQueryBuilder.ConditionCallback {
 		filterOptions: Set<ListFilterOption>,
 	): Flow<List<MangaWithTrack>> = observeMangaImpl(
 		MangaQueryBuilder("tracks", this)
-			.where("EXISTS(SELECT * FROM favourites WHERE favourites.manga_id = tracks.manga_id AND favourites.deleted_at = 0)")
 			.filters(filterOptions)
 			.limit(limit)
 			.orderBy("last_chapter_date DESC")

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
@@ -6,16 +6,18 @@ import org.koitharu.kotatsu.BuildConfig
 import org.koitharu.kotatsu.core.model.getPreferredBranch
 import org.koitharu.kotatsu.core.model.isLocal
 import org.koitharu.kotatsu.core.parser.CachingMangaRepository
+import org.koitharu.kotatsu.core.parser.MangaDataRepository
 import org.koitharu.kotatsu.core.parser.MangaRepository
+import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.core.util.MultiMutex
 import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
 import org.koitharu.kotatsu.core.util.ext.toInstantOrNull
 import org.koitharu.kotatsu.history.data.HistoryRepository
 import org.koitharu.kotatsu.local.data.LocalMangaRepository
 import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.util.findById
 import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
-import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.tracker.domain.model.MangaTracking
 import org.koitharu.kotatsu.tracker.domain.model.MangaUpdates
 import java.time.Instant
@@ -29,6 +31,7 @@ class CheckNewChaptersUseCase @Inject constructor(
 	private val mangaRepositoryFactory: MangaRepository.Factory,
 	private val localMangaRepository: LocalMangaRepository,
 	private val settings: AppSettings,
+	private val mangaDataRepository: MangaDataRepository,
 ) {
 
 	private val mutex = MultiMutex<Long>()
@@ -75,8 +78,19 @@ class CheckNewChaptersUseCase @Inject constructor(
 	}
 
 	private suspend fun invokeImpl(track: MangaTracking): MangaUpdates = runCatchingCancellable {
+		val cachedChapters = mangaDataRepository.findMangaById(track.manga.id, withChapters = true)
+			?.chapters
+			.orEmpty()
 		val details = getFullManga(track.manga)
-		compare(track, details, getBranch(details, track.lastChapterId))
+		val branch = getBranch(details, track.lastChapterId)
+		compare(
+			track = track,
+			manga = details,
+			branch = branch,
+			cachedChapterIds = cachedChapters.asSequence()
+				.filter { it.branch == branch }
+				.mapTo(HashSet()) { it.id },
+		)
 	}.getOrElse { error ->
 		MangaUpdates.Failure(
 			manga = track.manga,
@@ -119,17 +133,18 @@ class CheckNewChaptersUseCase @Inject constructor(
 		}
 	}
 
-	private fun compare(track: MangaTracking, manga: Manga, branch: String?): MangaUpdates.Success {
+	private fun compare(
+		track: MangaTracking,
+		manga: Manga,
+		branch: String?,
+		cachedChapterIds: Set<Long>,
+	): MangaUpdates.Success {
 		val chapters = requireNotNull(manga.getChapters(branch))
 		val installTime = settings.onboardingInstallTime
 		val lastCheckTime = track.lastCheck?.toEpochMilli() ?: installTime
 
 		if (track.isEmpty()) {
-			val newChapters = if (lastCheckTime > 0L) {
-				chapters.filter { x -> x.uploadDate > lastCheckTime }
-			} else {
-				emptyList()
-			}
+			val newChapters = chapters.findFallbackChapters(cachedChapterIds, lastCheckTime)
 			return MangaUpdates.Success(
 				manga = manga,
 				branch = branch,
@@ -152,11 +167,7 @@ class CheckNewChaptersUseCase @Inject constructor(
 			}
 
 			newChapters.size == chapters.size -> {
-				val fallbackChapters = if (lastCheckTime > 0L) {
-					chapters.filter { x -> x.uploadDate > lastCheckTime }
-				} else {
-					emptyList()
-				}
+				val fallbackChapters = chapters.findFallbackChapters(cachedChapterIds, lastCheckTime)
 				MangaUpdates.Success(manga, branch, fallbackChapters, isValid = fallbackChapters.isNotEmpty())
 			}
 
@@ -165,4 +176,45 @@ class CheckNewChaptersUseCase @Inject constructor(
 			}
 		}
 	}
+}
+
+private fun List<MangaChapter>.findFallbackChapters(
+	cachedChapterIds: Set<Long>,
+	lastCheckTime: Long,
+): List<MangaChapter> {
+	val fallbackIds = findFallbackChapterIds(
+		currentChapters = map { ChapterFingerprint(it.id, it.uploadDate) },
+		cachedChapterIds = cachedChapterIds,
+		lastCheckTime = lastCheckTime,
+	)
+	return filter { it.id in fallbackIds }
+}
+
+internal data class ChapterFingerprint(
+	val id: Long,
+	val uploadDate: Long,
+)
+
+internal fun findFallbackChapterIds(
+	currentChapters: List<ChapterFingerprint>,
+	cachedChapterIds: Set<Long>,
+	lastCheckTime: Long,
+): Set<Long> {
+	val datesAreAmbiguous = currentChapters.any { it.uploadDate <= 0L } ||
+		(currentChapters.size > 1 && currentChapters.all { it.uploadDate == currentChapters.first().uploadDate })
+	val cacheHasOverlap = cachedChapterIds.isNotEmpty() &&
+		currentChapters.any { it.id in cachedChapterIds }
+	if (datesAreAmbiguous && cacheHasOverlap) {
+		return currentChapters
+			.asSequence()
+			.filterNot { it.id in cachedChapterIds }
+			.mapTo(HashSet()) { it.id }
+	}
+	if (lastCheckTime <= 0L) {
+		return emptySet()
+	}
+	return currentChapters
+		.asSequence()
+		.filter { it.uploadDate > lastCheckTime }
+		.mapTo(HashSet()) { it.id }
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersUseCase.kt
@@ -15,6 +15,7 @@ import org.koitharu.kotatsu.local.data.LocalMangaRepository
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.util.findById
 import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
+import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.tracker.domain.model.MangaTracking
 import org.koitharu.kotatsu.tracker.domain.model.MangaUpdates
 import java.time.Instant
@@ -27,6 +28,7 @@ class CheckNewChaptersUseCase @Inject constructor(
 	private val historyRepository: HistoryRepository,
 	private val mangaRepositoryFactory: MangaRepository.Factory,
 	private val localMangaRepository: LocalMangaRepository,
+	private val settings: AppSettings,
 ) {
 
 	private val mutex = MultiMutex<Long>()
@@ -117,15 +119,24 @@ class CheckNewChaptersUseCase @Inject constructor(
 		}
 	}
 
-	/**
-	 * The main functionality of tracker: check new chapters in [manga] comparing to the [track]
-	 */
 	private fun compare(track: MangaTracking, manga: Manga, branch: String?): MangaUpdates.Success {
-		if (track.isEmpty()) {
-			// first check or manga was empty on last check
-			return MangaUpdates.Success(manga, branch, emptyList(), isValid = false)
-		}
 		val chapters = requireNotNull(manga.getChapters(branch))
+		val installTime = settings.onboardingInstallTime
+		val lastCheckTime = track.lastCheck?.toEpochMilli() ?: installTime
+
+		if (track.isEmpty()) {
+			val newChapters = if (lastCheckTime > 0L) {
+				chapters.filter { x -> x.uploadDate > lastCheckTime }
+			} else {
+				emptyList()
+			}
+			return MangaUpdates.Success(
+				manga = manga,
+				branch = branch,
+				newChapters = newChapters,
+				isValid = newChapters.isNotEmpty(),
+			)
+		}
 		if (BuildConfig.DEBUG && chapters.findById(track.lastChapterId) == null) {
 			Log.e("Tracker", "Chapter ${track.lastChapterId} not found")
 		}
@@ -141,7 +152,12 @@ class CheckNewChaptersUseCase @Inject constructor(
 			}
 
 			newChapters.size == chapters.size -> {
-				MangaUpdates.Success(manga, branch, emptyList(), isValid = false)
+				val fallbackChapters = if (lastCheckTime > 0L) {
+					chapters.filter { x -> x.uploadDate > lastCheckTime }
+				} else {
+					emptyList()
+				}
+				MangaUpdates.Success(manga, branch, fallbackChapters, isValid = fallbackChapters.isNotEmpty())
 			}
 
 			else -> {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
@@ -123,11 +123,15 @@ class TrackingRepository @Inject constructor(
 	}
 
 	suspend fun saveUpdates(updates: MangaUpdates) {
+		val hasNewChapters = updates is MangaUpdates.Success &&
+			updates.isValid &&
+			updates.newChapters.isNotEmpty()
 		db.withTransaction {
 			val track = getOrCreateTrack(updates.manga.id).mergeWith(updates)
 			db.getTracksDao().upsert(track)
-			if (updates is MangaUpdates.Success && updates.isValid && updates.newChapters.isNotEmpty()) {
+			if (hasNewChapters) {
 				progressUpdateUseCase(updates.manga)
+				check(updates is MangaUpdates.Success)
 				val logEntity = TrackLogEntity(
 					mangaId = updates.manga.id,
 					chapters = updates.newChapters.joinToString("\n") { x -> x.title.orEmpty() },
@@ -136,6 +140,9 @@ class TrackingRepository @Inject constructor(
 				)
 				db.getTrackLogsDao().insert(logEntity)
 			}
+		}
+		if (hasNewChapters) {
+			settings.restoreFeedItem(updates.manga.id)
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/TrackingRepository.kt
@@ -92,6 +92,20 @@ class TrackingRepository @Inject constructor(
 			.onStart { gcIfNotCalled() }
 	}
 
+	fun observeAllTracks(limit: Int, filterOptions: Set<ListFilterOption>): Flow<List<MangaTracking>> {
+		return db.getTracksDao().observeAllTracks(limit, filterOptions)
+			.mapItems {
+				MangaTracking(
+					manga = it.manga.toManga(it.tags.toMangaTags(), null),
+					lastChapterId = it.track.lastChapterId,
+					lastCheck = it.track.lastCheckTime.toInstantOrNull(),
+					lastChapterDate = it.track.lastChapterDate.toInstantOrNull(),
+					newChapters = it.track.newChapters,
+				)
+			}.distinctUntilChanged()
+			.onStart { gcIfNotCalled() }
+	}
+
 	suspend fun getLogsCount() = db.getTrackLogsDao().count()
 
 	suspend fun clearLogs() = db.getTrackLogsDao().clear()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/TrackingLogItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/TrackingLogItem.kt
@@ -9,4 +9,5 @@ data class TrackingLogItem(
 	val chapters: List<String>,
 	val createdAt: Instant,
 	val isNew: Boolean,
+	val count: Int = chapters.size,
 )

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/TrackingLogItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/domain/model/TrackingLogItem.kt
@@ -10,4 +10,5 @@ data class TrackingLogItem(
 	val createdAt: Instant,
 	val isNew: Boolean,
 	val count: Int = chapters.size,
+	val showTotal: Boolean = false,
 )

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
@@ -64,8 +64,13 @@ class FeedViewModel @Inject constructor(
 	@Suppress("USELESS_CAST")
 	val content = combine(
 		quickFilter.appliedOptions,
-		combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
-			.flatMapLatest { repository.observeAllTracks(it.first, it.second) }
+		combine(
+			combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
+				.flatMapLatest { repository.observeAllTracks(it.first, it.second) },
+			settings.observeAsFlow(AppSettings.KEY_DISMISSED_FEED_ITEMS) { dismissedFeedItems },
+		) { tracks, dismissedItems ->
+			tracks.filterNot { it.manga.id.toString() in dismissedItems }
+		}
 			.mapLatest { tracks ->
 				val result = ArrayList<TrackingLogItem>(tracks.size)
 				for (track in tracks) {
@@ -116,6 +121,9 @@ class FeedViewModel @Inject constructor(
 
 	fun clearFeed(clearCounters: Boolean) {
 		launchLoadingJob(Dispatchers.Default) {
+			settings.dismissFeedItems(
+				repository.getTracks(0, Int.MAX_VALUE).map { it.manga.id },
+			)
 			repository.clearLogs()
 			if (clearCounters) {
 				repository.clearCounters()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.plus
 import org.koitharu.kotatsu.R
@@ -21,6 +22,7 @@ import org.koitharu.kotatsu.core.ui.model.DateTimeAgo
 import org.koitharu.kotatsu.core.ui.util.ReversibleAction
 import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
 import org.koitharu.kotatsu.core.util.ext.calculateTimeAgo
+import org.koitharu.kotatsu.core.util.ext.groupByDateBucket
 import org.koitharu.kotatsu.core.util.ext.call
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 import org.koitharu.kotatsu.list.domain.MangaListMapper
@@ -61,7 +63,19 @@ class FeedViewModel @Inject constructor(
 	val content = combine(
 		quickFilter.appliedOptions,
 		combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
-			.flatMapLatest { repository.observeTrackingLog(it.first, it.second) },
+			.flatMapLatest { repository.observeAllTracks(it.first, it.second) }
+			.mapLatest { tracks ->
+				tracks.map { track ->
+					TrackingLogItem(
+						id = -track.manga.id,
+						manga = track.manga,
+						chapters = emptyList(),
+						createdAt = track.lastChapterDate ?: track.lastCheck ?: java.time.Instant.EPOCH,
+						isNew = track.newChapters > 0,
+						count = track.newChapters,
+					)
+				}
+			},
 	) { filters, list ->
 		val result = ArrayList<ListModel>((list.size * 1.4).toInt().coerceAtLeast(3))
 		quickFilter.filterItem(filters)?.let(result::add)
@@ -110,23 +124,24 @@ class FeedViewModel @Inject constructor(
 	@OptIn(DelicateCoroutinesApi::class)
 	fun onItemClick(item: FeedItem) {
 		launchJob(Dispatchers.Default, CoroutineStart.ATOMIC) {
-			repository.markAsRead(item.id)
+			if (item.id > 0L) {
+				repository.markAsRead(item.id)
+			}
 		}
 	}
 
 	private suspend fun List<TrackingLogItem>.mapListTo(destination: MutableList<ListModel>) {
-		var prevDate: DateTimeAgo? = null
-		for (item in this) {
-			val date = calculateTimeAgo(item.createdAt)
-			if (prevDate != date) {
-				destination += if (date != null) {
-					ListHeader(date)
-				} else {
-					ListHeader(R.string.unknown)
-				}
+		val feedItems = map { mangaListMapper.toFeedItem(it) }
+		val bucketedItems = zip(feedItems).groupByDateBucket(instantOf = { it.first.createdAt })
+		for ((date, items) in bucketedItems) {
+			destination += if (date != null) {
+				ListHeader(date)
+			} else {
+				ListHeader(R.string.unknown)
 			}
-			prevDate = date
-			destination += mangaListMapper.toFeedItem(item)
+			for ((_, feedItem) in items) {
+				destination += feedItem
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.plus
+import org.koitharu.kotatsu.core.db.MangaDatabase
 import org.koitharu.kotatsu.R
 import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.core.prefs.observeAsFlow
@@ -49,6 +50,7 @@ class FeedViewModel @Inject constructor(
 	private val scheduler: TrackWorker.Scheduler,
 	private val mangaListMapper: MangaListMapper,
 	private val quickFilter: UpdatesListQuickFilter,
+	private val db: MangaDatabase,
 ) : BaseViewModel(), QuickFilterListener by quickFilter {
 
 	private val limit = MutableStateFlow(PAGE_SIZE)
@@ -65,16 +67,27 @@ class FeedViewModel @Inject constructor(
 		combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
 			.flatMapLatest { repository.observeAllTracks(it.first, it.second) }
 			.mapLatest { tracks ->
-				tracks.map { track ->
-					TrackingLogItem(
+				val result = ArrayList<TrackingLogItem>(tracks.size)
+				for (track in tracks) {
+					val date = track.lastChapterDate ?: track.lastCheck ?: java.time.Instant.EPOCH
+					val isToday = calculateTimeAgo(date).let { it == DateTimeAgo.Today || it == DateTimeAgo.JustNow }
+					val showTotal = !isToday && track.newChapters == 0
+					val count = if (showTotal) {
+						db.getChaptersDao().getChaptersCount(track.manga.id)
+					} else {
+						track.newChapters
+					}
+					result += TrackingLogItem(
 						id = -track.manga.id,
 						manga = track.manga,
 						chapters = emptyList(),
-						createdAt = track.lastChapterDate ?: track.lastCheck ?: java.time.Instant.EPOCH,
+						createdAt = date,
 						isNew = track.newChapters > 0,
-						count = track.newChapters,
+						count = count,
+						showTotal = showTotal,
 					)
 				}
+				result
 			},
 	) { filters, list ->
 		val result = ArrayList<ListModel>((list.size * 1.4).toInt().coerceAtLeast(3))

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/adapter/FeedItemAD.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/adapter/FeedItemAD.kt
@@ -24,11 +24,19 @@ fun feedItemAD(
 	bind {
 		binding.imageViewCover.setImageAsync(item.imageUrl, item.manga.source)
 		binding.textViewTitle.text = item.title
-		binding.textViewSummary.text = context.resources.getQuantityStringSafe(
-			R.plurals.new_chapters,
-			item.count,
-			item.count,
-		)
+		binding.textViewSummary.text = if (item.showTotal) {
+			context.resources.getQuantityStringSafe(
+				R.plurals.total_chapters,
+				item.count,
+				item.count,
+			)
+		} else {
+			context.resources.getQuantityStringSafe(
+				R.plurals.new_chapters,
+				item.count,
+				item.count,
+			)
+		}
 		binding.textViewSummary.drawableStart = if (item.isNew) {
 			indicatorNew
 		} else {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/model/FeedItem.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/model/FeedItem.kt
@@ -13,6 +13,7 @@ data class FeedItem(
 	val manga: Manga,
 	val count: Int,
 	val isNew: Boolean,
+	val showTotal: Boolean = false,
 ) : ListModel {
 
 	val imageUrl: String?

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -8,6 +8,10 @@
 		<item quantity="one">%1$d new chapter</item>
 		<item quantity="other">%1$d new chapters</item>
 	</plurals>
+	<plurals name="total_chapters">
+		<item quantity="one">%1$d total chapter</item>
+		<item quantity="other">%1$d total chapters</item>
+	</plurals>
 	<plurals name="manga_failed_to_fetch_new_chapters">
 		<item quantity="one">%1$d manga failed to fetch new chapters.</item>
 		<item quantity="other">%1$d manga failed to fetch new chapters.</item>

--- a/app/src/test/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersFallbackTest.kt
+++ b/app/src/test/kotlin/org/koitharu/kotatsu/tracker/domain/CheckNewChaptersFallbackTest.kt
@@ -1,0 +1,63 @@
+package org.koitharu.kotatsu.tracker.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CheckNewChaptersFallbackTest {
+
+	@Test
+	fun `missing dates use cached chapter ids`() {
+		val current = chapters(
+			1L to 0L,
+			2L to 0L,
+			3L to 0L,
+		)
+
+		val result = findFallbackChapterIds(current, setOf(1L, 2L), lastCheckTime = 100L)
+
+		assertEquals(setOf(3L), result)
+	}
+
+	@Test
+	fun `identical dates use cached chapter ids`() {
+		val current = chapters(
+			1L to 50L,
+			2L to 50L,
+			3L to 50L,
+		)
+
+		val result = findFallbackChapterIds(current, setOf(1L, 2L), lastCheckTime = 100L)
+
+		assertEquals(setOf(3L), result)
+	}
+
+	@Test
+	fun `reliable dates retain existing date fallback`() {
+		val current = chapters(
+			1L to 50L,
+			2L to 100L,
+			3L to 150L,
+		)
+
+		val result = findFallbackChapterIds(current, setOf(1L), lastCheckTime = 125L)
+
+		assertEquals(setOf(3L), result)
+	}
+
+	@Test
+	fun `unrelated cache retains existing date fallback`() {
+		val current = chapters(
+			1L to 50L,
+			2L to 50L,
+			3L to 50L,
+		)
+
+		val result = findFallbackChapterIds(current, setOf(10L, 11L), lastCheckTime = 25L)
+
+		assertEquals(setOf(1L, 2L, 3L), result)
+	}
+
+	private fun chapters(vararg values: Pair<Long, Long>) = values.map { (id, date) ->
+		ChapterFingerprint(id = id, uploadDate = date)
+	}
+}


### PR DESCRIPTION
This pull request introduces several improvements to how manga chapters and updates are tracked and displayed in the feed. The main changes include enhanced grouping of feed items by date, more accurate chapter counts, and clearer display of total versus new chapters. The codebase also gains new utility methods and database queries to support these features.

**Feed grouping and display improvements:**

* Feed items are now grouped by date buckets using the new `groupByDateBucket` utility, resulting in a clearer and more organized feed UI. [[1]](diffhunk://#diff-5a673cf9d723a9d9893792b72309c790ed5ef3606d0b4db9998f174827688477R55-R79) [[2]](diffhunk://#diff-0d9623a62f0dd68557e0528f8e3ffe77f9dafc9bc8f9fc1790c59e23282cd4ddR140-L129)
* Feed items now differentiate between showing the total number of chapters and the count of new chapters, using a new plural resource and logic to determine which to display. [[1]](diffhunk://#diff-0d9623a62f0dd68557e0528f8e3ffe77f9dafc9bc8f9fc1790c59e23282cd4ddL64-R91) [[2]](diffhunk://#diff-8479485dc2213d046e2e35479b7f7143fac6c8067e24519a4d2ae9d095a14477L27-R39) [[3]](diffhunk://#diff-5775c333072e5dd6709c5d6e3fb711ce225cbdeea8dc2722f7fb4f5f8d61d235R16) [[4]](diffhunk://#diff-deb37a0695f5a08818ff7155b4216fbb8cac993edfc13ca0fe3737dbece22ebcR12-R13) [[5]](diffhunk://#diff-adee133096bf45651f166754a927b9e30cefbfb704299a55ff9172be109671d5R11-R14)

**Data and repository enhancements:**

* Added a new database query `getChaptersCount` in `ChaptersDao` to retrieve the total number of chapters for a manga.
* Introduced `observeAllTracks` in both `TracksDao` and `TrackingRepository` to observe all manga tracks with filtering and limiting support. [[1]](diffhunk://#diff-99facc288d05a34003dc93436cd2ac05e71d3be22b5faa78016bf69005ddf067R62-R73) [[2]](diffhunk://#diff-f8a9f618f0286f2cb860610187c8b3e5e810ea9118fb4465d44637a75d79d4fdR95-R108)

**Tracking logic improvements:**

* The logic for determining new chapters in `CheckNewChaptersUseCase` now considers the app's onboarding install time, and falls back to showing chapters uploaded since the last check if needed. [[1]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22R31) [[2]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22L120-L128) [[3]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22L144-R160) [[4]](diffhunk://#diff-4da318e8b65cfcc6ef38b325c0548e6d18f0c238340dcf4a685771e55508e4ebR112-R114) [[5]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22R18)

**Model and mapping updates:**

* `TrackingLogItem` and `FeedItem` models now include fields for total count and whether to show the total, and `MangaListMapper` is updated to map these fields. [[1]](diffhunk://#diff-deb37a0695f5a08818ff7155b4216fbb8cac993edfc13ca0fe3737dbece22ebcR12-R13) [[2]](diffhunk://#diff-2f98232eed9c2288e963b836a351857bf6acbfdd9f343a513ae937b112179b20L84-R87) [[3]](diffhunk://#diff-5775c333072e5dd6709c5d6e3fb711ce225cbdeea8dc2722f7fb4f5f8d61d235R16)

**Dependency and injection changes:**

* Several classes now inject `MangaDatabase` and `AppSettings` to support new features and logic. [[1]](diffhunk://#diff-0d9623a62f0dd68557e0528f8e3ffe77f9dafc9bc8f9fc1790c59e23282cd4ddR53) [[2]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22R31) [[3]](diffhunk://#diff-df0e1b340d76393652adc804af8abf07008d817477caa451243acfccc8748e22R18)

These changes together provide a more informative and user-friendly manga updates feed, with improved accuracy and grouping of update items.