### PR TITLE
Fix Shizuku installer timeout in release builds (R8 strips the user service)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,6 +33,15 @@
 -keep class org.koitharu.kotatsu.**Fragment { *; }
 
 # ============================================================
+# Shizuku user service
+# Instantiated via Class.newInstance() by Shizuku's ServiceStarter
+# in a separate process; the app never references its constructor
+# or methods directly, so R8 would otherwise strip them and the
+# service process dies with InstantiationException.
+# ============================================================
+-keep class org.koitharu.kotatsu.extensions.install.shizuku.** { *; }
+
+# ============================================================
 # Mihon Extension Support
 # Extensions are separate APKs loaded at runtime via
 # ChildFirstPathClassLoader. They depend on these host classes.

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourcesCatalogActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/sources/catalog/SourcesCatalogActivity.kt
@@ -115,6 +115,7 @@ class SourcesCatalogActivity : BaseActivity<ActivitySourcesCatalogBinding>(),
 			} else {
 				viewModel.clearExtensionInProgress(downloadRequestsById.remove(downloadId)?.packageName)
 				removeDownloadedApk(downloadId)
+				Toast.makeText(this, R.string.extension_download_failed, Toast.LENGTH_LONG).show()
 			}
 			settings.pendingExtensionDownloads = pendingInstallerDownloads
 			processDownloadedInstallerQueue()
@@ -744,6 +745,7 @@ class SourcesCatalogActivity : BaseActivity<ActivitySourcesCatalogBinding>(),
 		val pendingSnapshot = pendingInstallerDownloads.toLongArray()
 		val query = DownloadManager.Query().setFilterById(*pendingSnapshot)
 		val cursor = downloadManager.query(query) ?: return
+		var anyFailed = false
 		cursor.use {
 			val idColumn = it.getColumnIndex(DownloadManager.COLUMN_ID)
 			val statusColumn = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
@@ -758,10 +760,14 @@ class SourcesCatalogActivity : BaseActivity<ActivitySourcesCatalogBinding>(),
 				} else if (status == DownloadManager.STATUS_FAILED) {
 					viewModel.clearExtensionInProgress(downloadRequestsById.remove(id)?.packageName)
 					removeDownloadedApk(id)
+					anyFailed = true
 				} else {
 					pendingInstallerDownloads += id
 				}
 			}
+		}
+		if (anyFailed) {
+			Toast.makeText(this, R.string.extension_download_failed, Toast.LENGTH_LONG).show()
 		}
 		settings.pendingExtensionDownloads = pendingInstallerDownloads
 		processDownloadedInstallerQueue()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -432,6 +432,7 @@
     <string name="scrobbling_empty_hint">To track reading progress, select Menu -> Track on the manga details screen.</string>
     <string name="services">Services</string>
     <string name="download_started">Download started</string>
+    <string name="extension_download_failed">Extension download failed. Check your connection and try again.</string>
     <string name="got_it">Got it</string>
     <string name="user_agent">UserAgent header</string>
     <string name="settings_apply_restart_required">Please restart the application to apply these changes</string>


### PR DESCRIPTION
## Problem

On release builds, installing or updating extensions via Shizuku always fails with a timeout after ~15 seconds, even with Shizuku running and permission granted. Debug builds work fine.

## Root cause

`ShizukuInstallerService` is only referenced via `ComponentName(context, ShizukuInstallerService::class.java)` and invoked remotely through the AIDL proxy — nothing in the app instantiates it or calls its methods directly. With `minifyEnabled = true`, R8 therefore strips its constructor and all method bodies, leaving a `PUBLIC ABSTRACT` shell in the dex (verified with dexdump against the published v0.5.0 APK).

When Shizuku's `ServiceStarter` spawns the user-service process and calls `Class.newInstance()`, it throws:

```
java.lang.InstantiationException: java.lang.Class<org.koitharu.kotatsu.extensions.install.shizuku.ShizukuInstallerService> cannot be instantiated
    at java.lang.Class.newInstance(Native Method)
    at moe.shizuku.starter.ServiceStarter.main(SourceFile:14)
```

The process exits with status 1, `onServiceConnected` never fires, and `ShizukuExtensionInstaller` hits its 15s `BIND_TIMEOUT_MS`, surfacing as "Timed out…" on every install. This also silently breaks the background `ExtensionUpdateWorker` auto-update path.

## Fix

- Add a ProGuard keep rule for `org.koitharu.kotatsu.extensions.install.shizuku.**`. Verified on a minified build that the class retains its constructor, `install`, and `destroy` after the change, and that installs complete on a real device (Android 16, Shizuku via root).
- Bonus: show a toast when an extension APK download fails. Previously the progress indicator was cleared with no feedback, which made intermittent HTTP 429s from `raw.githubusercontent.com` (common on mobile data behind CGNAT) look like the installer hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)