### PR TITLE
Add downloads index rebuild in settings

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/DownloadsSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/DownloadsSettingsFragment.kt
@@ -62,6 +62,25 @@ import org.koitharu.kotatsu.settings.compose.SwitchSettingsItem
 import org.koitharu.kotatsu.settings.compose.rememberBooleanPref
 import org.koitharu.kotatsu.settings.compose.rememberStringPref
 import javax.inject.Inject
+import org.koitharu.kotatsu.favourites.domain.FavouritesRepository
+import org.koitharu.kotatsu.local.data.index.LocalMangaIndex
+import org.koitharu.kotatsu.core.parser.MangaRepository
+import org.koitharu.kotatsu.core.parser.MangaDataRepository
+import org.koitharu.kotatsu.alternatives.domain.MigrateUseCase
+import org.koitharu.kotatsu.mihon.MihonExtensionManager
+import org.koitharu.kotatsu.local.data.MangaIndex
+import org.koitharu.kotatsu.local.data.input.LocalMangaParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.core.util.ext.toFileNameSafe
+import org.koitharu.kotatsu.parsers.util.nullIfEmpty
+import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
+import org.koitharu.kotatsu.core.ui.dialog.buildAlertDialog
+import android.widget.Toast
+import java.io.File
+import org.json.JSONObject
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 @AndroidEntryPoint
 class DownloadsSettingsFragment :
@@ -76,6 +95,24 @@ class DownloadsSettingsFragment :
 
 	@Inject
 	lateinit var settings: AppSettings
+
+	@Inject
+	lateinit var favouritesRepository: FavouritesRepository
+
+	@Inject
+	lateinit var localMangaIndex: LocalMangaIndex
+
+	@Inject
+	lateinit var mangaRepositoryFactory: MangaRepository.Factory
+
+	@Inject
+	lateinit var mangaDataRepository: MangaDataRepository
+
+	@Inject
+	lateinit var migrateUseCase: MigrateUseCase
+
+	@Inject
+	lateinit var mihonExtensionManager: MihonExtensionManager
 
 	private val storageSummary = MutableStateFlow<String?>(null)
 	private val directoryCount = MutableStateFlow(0)
@@ -111,6 +148,7 @@ class DownloadsSettingsFragment :
 					onMeteredChanged = { updateDownloadsConstraints() },
 					onPickPagesDir = ::launchPagesDirPicker,
 					onIgnoreDoze = ::startIgnoreDoseActivity,
+					onRebuildDownloadsIndex = ::rebuildDownloadsIndex,
 				)
 			}
 		}
@@ -210,6 +248,258 @@ class DownloadsSettingsFragment :
 			).show()
 		}
 	}
+
+	private enum class MigrationChoice {
+		MIGRATE,
+		KEEP
+	}
+
+	private suspend fun showMigrationDialog(
+		mangaTitle: String,
+		localSource: String,
+		favoriteSource: String
+	): MigrationChoice = withContext(Dispatchers.Main) {
+		suspendCancellableCoroutine { continuation ->
+			val dialog = buildAlertDialog(requireContext()) {
+				setTitle(R.string.rebuild_source_mismatch_title)
+				setMessage(getString(R.string.rebuild_source_mismatch_message, mangaTitle, localSource, favoriteSource))
+				setPositiveButton(getString(R.string.rebuild_migrate_to, localSource)) { _, _ ->
+					if (continuation.isActive) continuation.resume(MigrationChoice.MIGRATE)
+				}
+				setNegativeButton(getString(R.string.rebuild_keep_on, favoriteSource)) { _, _ ->
+					if (continuation.isActive) continuation.resume(MigrationChoice.KEEP)
+				}
+				setOnCancelListener {
+					if (continuation.isActive) continuation.resume(MigrationChoice.KEEP)
+				}
+			}
+			dialog.show()
+			continuation.invokeOnCancellation {
+				dialog.dismiss()
+			}
+		}
+	}
+
+	private fun getNormalizedSourceName(sourceName: String): String {
+		val clean = sourceName.removePrefix("MIHON_").substringBefore(':')
+		val sourceId = clean.toLongOrNull()
+		if (sourceId != null) {
+			val mihonSource = mihonExtensionManager.getMihonMangaSourceById(sourceId)
+			if (mihonSource != null) {
+				return mihonSource.displayName.lowercase(java.util.Locale.ROOT).replace(Regex("[^a-z0-9]"), "")
+			}
+		}
+		return clean.lowercase(java.util.Locale.ROOT).replace(Regex("[^a-z0-9]"), "")
+	}
+
+	private fun isSameOrSimilarSource(sourceA: String, sourceB: String): Boolean {
+		if (sourceA == sourceB) return true
+		val normA = getNormalizedSourceName(sourceA)
+		val normB = getNormalizedSourceName(sourceB)
+		return normA.isNotEmpty() && normB.isNotEmpty() && (normA == normB || normA.contains(normB) || normB.contains(normA))
+	}
+
+	private fun extractChapterNumber(filename: String): Float? {
+		val name = filename.substringBeforeLast('.')
+		val regexChapter = Regex("(?i)\\b(?:c|ch|chap|chapter)\\.?\\s*([0-9]+(?:\\.[0-9]+)?)")
+		regexChapter.find(name)?.groupValues?.get(1)?.toFloatOrNull()?.let {
+			return it
+		}
+		val regexNumber = Regex("([0-9]+(?:\\.[0-9]+)?)")
+		val matches = regexNumber.findAll(name).toList()
+		if (matches.isNotEmpty()) {
+			matches.last().groupValues[1].toFloatOrNull()?.let {
+				return it
+			}
+		}
+		return null
+	}
+
+	private fun matchChapters(
+		mangaFolder: File,
+		chapters: List<MangaChapter>,
+		oldIndexJson: JSONObject?
+	): Map<IndexedValue<MangaChapter>, String> {
+		val matched = mutableMapOf<IndexedValue<MangaChapter>, String>()
+		val remainingChapters = chapters.mapIndexed { idx, ch -> IndexedValue(idx, ch) }.toMutableList()
+		val files = mangaFolder.listFiles()?.filter {
+			val ext = it.name.substringAfterLast('.', "").lowercase(java.util.Locale.ROOT)
+			it.isFile && (ext == "cbz" || ext == "zip")
+		}.orEmpty()
+
+		if (oldIndexJson != null) {
+			val oldChaptersJson = oldIndexJson.optJSONObject("chapters")
+			if (oldChaptersJson != null) {
+				val keys = oldChaptersJson.keys()
+				while (keys.hasNext()) {
+					val key = keys.next()
+					val chJson = oldChaptersJson.getJSONObject(key)
+					val fileName = chJson.optString("file").nullIfEmpty() ?: continue
+					val file = File(mangaFolder, fileName)
+					if (!file.exists()) continue
+
+					val number = chJson.optDouble("number", Double.NaN)
+					val name = chJson.optString("name").nullIfEmpty()
+					val branch = chJson.optString("branch").nullIfEmpty()
+
+					val match = remainingChapters.find {
+						(!number.isNaN() && it.value.number == number.toFloat() && (branch == null || it.value.branch == branch))
+					} ?: remainingChapters.find {
+						(!number.isNaN() && it.value.number == number.toFloat())
+					} ?: remainingChapters.find {
+						(name != null && it.value.title?.equals(name, ignoreCase = true) == true)
+					}
+
+					if (match != null) {
+						matched[match] = fileName
+						remainingChapters.remove(match)
+					}
+				}
+			}
+		}
+
+		val remainingFiles = files.filter { it.name !in matched.values }
+		for (file in remainingFiles) {
+			val nameWithoutExt = file.name.substringBeforeLast('.')
+			val indexPart = nameWithoutExt.substringBefore('_').toIntOrNull() ?: nameWithoutExt.toIntOrNull()
+			if (indexPart != null) {
+				val match = remainingChapters.find { it.index == indexPart }
+				if (match != null) {
+					matched[match] = file.name
+					remainingChapters.remove(match)
+					continue
+				}
+			}
+
+			val numberPart = extractChapterNumber(file.name)
+			if (numberPart != null) {
+				val match = remainingChapters.find { it.value.number == numberPart }
+				if (match != null) {
+					matched[match] = file.name
+					remainingChapters.remove(match)
+					continue
+				}
+			}
+		}
+		return matched
+	}
+
+	private fun rebuildDownloadsIndex() {
+		lifecycleScope.launch {
+			withContext(Dispatchers.Main) {
+				Toast.makeText(requireContext(), R.string.rebuild_downloads_index_started, Toast.LENGTH_SHORT).show()
+			}
+			var updatedCount = 0
+			try {
+				val favorites = favouritesRepository.getAllManga()
+				val roots = storageManager.getReadableDirs()
+				for (favorite in favorites) {
+					val safeTitle = favorite.title.toFileNameSafe()
+					for (root in roots) {
+						val mangaFolder = File(root, safeTitle)
+						if (mangaFolder.isDirectory) {
+							val indexFile = File(mangaFolder, "index.json")
+							val oldIndexJson = if (indexFile.isFile) {
+								runCatching { JSONObject(indexFile.readText()) }.getOrNull()
+							} else {
+								null
+							}
+
+							var currentFavorite = favorite
+							var skipFolder = false
+
+							if (oldIndexJson != null) {
+								val oldId = oldIndexJson.optLong("id", 0L)
+								val oldSource = oldIndexJson.optString("source").nullIfEmpty()
+								if (oldId != 0L && oldId != favorite.id && oldSource != null) {
+									// Conflict detected!
+									if (isSameOrSimilarSource(oldSource, favorite.source.name)) {
+										// Auto resolve by overwriting index with favorite's metadata
+										// Do nothing here, just keep currentFavorite
+									} else {
+										// Totally different source: prompt user
+										val localMangaInfo = runCatching { LocalMangaParser(mangaFolder).getMangaInfo() }.getOrNull()
+										if (localMangaInfo != null) {
+											val choice = showMigrationDialog(
+												favorite.title,
+												localMangaInfo.source.name,
+												favorite.source.name
+											)
+											if (choice == MigrationChoice.MIGRATE) {
+												migrateUseCase(oldManga = favorite, newManga = localMangaInfo)
+												// After migration, the favorite entry in DropSauce uses localMangaInfo's ID & source
+												currentFavorite = localMangaInfo
+											} else {
+												skipFolder = true
+											}
+										} else {
+											skipFolder = true
+										}
+									}
+								}
+							}
+
+							if (skipFolder) continue
+
+							// Fetch or retrieve chapters
+							var chapters = mangaDataRepository.findMangaById(currentFavorite.id, withChapters = true)?.chapters.orEmpty()
+							if (chapters.isEmpty()) {
+								runCatchingCancellable {
+									val repo = mangaRepositoryFactory.create(currentFavorite.source)
+									val remote = repo.getDetails(currentFavorite)
+									mangaDataRepository.storeManga(remote, replaceExisting = true, detailsFetched = true)
+									chapters = remote.chapters.orEmpty()
+								}.onFailure {
+									it.printStackTraceDebug()
+								}
+							}
+
+							val matched = matchChapters(mangaFolder, chapters, oldIndexJson)
+
+							val newIndex = MangaIndex(null)
+							newIndex.setMangaInfo(currentFavorite)
+
+							val oldCoverEntry = oldIndexJson?.optString("cover_entry")?.nullIfEmpty()
+							val coverName = when {
+								oldCoverEntry != null && File(mangaFolder, oldCoverEntry).exists() -> oldCoverEntry
+								File(mangaFolder, "cover.jpg").exists() -> "cover.jpg"
+								File(mangaFolder, "cover.png").exists() -> "cover.png"
+								else -> null
+							}
+							if (coverName != null) {
+								newIndex.setCoverEntry(coverName)
+							}
+
+							for ((chapter, filename) in matched) {
+								newIndex.addChapter(chapter, filename)
+							}
+
+							runCatching {
+								indexFile.writeText(newIndex.toString())
+								updatedCount++
+							}.onFailure {
+								it.printStackTraceDebug()
+							}
+						}
+					}
+				}
+
+				localMangaIndex.update()
+				withContext(Dispatchers.Main) {
+					Toast.makeText(
+						requireContext(),
+						getString(R.string.rebuild_downloads_index_completed, updatedCount),
+						Toast.LENGTH_LONG
+					).show()
+				}
+			} catch (e: Exception) {
+				e.printStackTraceDebug()
+				withContext(Dispatchers.Main) {
+					Toast.makeText(requireContext(), "Error: ${e.localizedMessage}", Toast.LENGTH_LONG).show()
+				}
+			}
+		}
+	}
 }
 
 @Composable
@@ -224,6 +514,7 @@ private fun DownloadsScreen(
 	onMeteredChanged: () -> Unit,
 	onPickPagesDir: () -> Unit,
 	onIgnoreDoze: () -> Unit,
+	onRebuildDownloadsIndex: () -> Unit,
 ) {
 	val ctx = LocalContext.current
 	val storage by storageSummary.collectAsState()
@@ -296,6 +587,15 @@ private fun DownloadsScreen(
 						icon = R.drawable.ic_network_cellular,
 						
 						shape = pos.shape,
+					)
+				}
+				item { pos ->
+					ActionSettingsItem(
+						title = stringResource(R.string.rebuild_downloads_index),
+						subtitle = stringResource(R.string.rebuild_downloads_index_summary),
+						icon = R.drawable.ic_sync,
+						shape = pos.shape,
+						onClick = onRebuildDownloadsIndex,
 					)
 				}
 				if (showDoze) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -913,6 +913,14 @@
     <string name="chapters_all">All</string>
     <string name="download_over_cellular">Downloading over cellular network</string>
     <string name="download_cellular_confirm">Allow downloads over cellular network?</string>
+    <string name="rebuild_downloads_index">Rebuild Downloads Index</string>
+    <string name="rebuild_downloads_index_summary">Scan download folders to verify previous downloads and build index files for compatibility.</string>
+    <string name="rebuild_downloads_index_started">Rebuilding downloads index…</string>
+    <string name="rebuild_downloads_index_completed">Downloads index rebuilt: %1$d folders updated</string>
+    <string name="rebuild_source_mismatch_title">Source Mismatch</string>
+    <string name="rebuild_source_mismatch_message">This local manga \"%1$s\" comes from %2$s, while your favorite comes from %3$s. Do you wish to migrate to %2$s or keep on %3$s?</string>
+    <string name="rebuild_migrate_to">Migrate to %1$s</string>
+    <string name="rebuild_keep_on">Keep on %1$s</string>
     <string name="dont_allow">Don\'t allow</string>
     <string name="allow_always">Allow always</string>
     <string name="allow_once">Allow once</string>


### PR DESCRIPTION
Adds a new Downloads settings action to rebuild local `index.json` files by scanning download folders and matching archived chapter files to known chapters. The flow preserves covers, refreshes the local index, and reports progress/results with toasts. It also handles source-ID mismatches by normalizing similar sources automatically and prompting the user to migrate or keep the current favorite when sources differ.