### PR TITLE
ci: restore PR lint checks, fix release heredoc, and clean up build config

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Pre-warm JitPack dependencies
         run: |
-          PARSERS_VERSION=$(grep 'parsers = ' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          PARSERS_VERSION=$(grep '^parsers = ' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "Pre-warming JitPack for kotatsu-parsers:${PARSERS_VERSION}"
           POM_URL="https://jitpack.io/com/github/YakaTeam/kotatsu-parsers/${PARSERS_VERSION}/kotatsu-parsers-${PARSERS_VERSION}.pom"
           for i in $(seq 1 10); do

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,71 @@
+name: PR Checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Pre-warm JitPack dependencies
+        run: |
+          PARSERS_VERSION=$(grep 'parsers = ' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          echo "Pre-warming JitPack for kotatsu-parsers:${PARSERS_VERSION}"
+          POM_URL="https://jitpack.io/com/github/YakaTeam/kotatsu-parsers/${PARSERS_VERSION}/kotatsu-parsers-${PARSERS_VERSION}.pom"
+          for i in $(seq 1 10); do
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$POM_URL")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "JitPack artifact is ready (HTTP 200)"
+              exit 0
+            fi
+            echo "Attempt $i: JitPack returned HTTP ${HTTP_STATUS}, waiting 30s..."
+            sleep 30
+          done
+          echo "::warning::JitPack artifact for kotatsu-parsers:${PARSERS_VERSION} not available after 10 attempts"
+          exit 0
+
+      - name: Run Android Lint
+        run: ./gradlew lintDebug --no-daemon --stacktrace
+        continue-on-error: true
+
+      - name: Upload Lint SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('app/build/reports/lint-results-debug.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        continue-on-error: true
+        with:
+          sarif_file: app/build/reports/lint-results-debug.sarif
+          category: android-lint
+
+      - name: Upload Lint SARIF as Workflow Artifact
+        uses: actions/upload-artifact@v5
+        if: always() && hashFiles('app/build/reports/lint-results-debug.sarif') != ''
+        with:
+          name: lint-results-sarif
+          path: app/build/reports/lint-results-debug.sarif

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -102,7 +102,7 @@ jobs:
           cat release-notes.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload preview APK as a workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.apk.outputs.apk_name }}
           path: ${{ steps.apk.outputs.apk_name }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Pre-warm JitPack dependencies
         run: |
-          PARSERS_VERSION=$(grep 'parsers = ' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          PARSERS_VERSION=$(grep '^parsers = ' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "Pre-warming JitPack for kotatsu-parsers:${PARSERS_VERSION}"
           POM_URL="https://jitpack.io/com/github/YakaTeam/kotatsu-parsers/${PARSERS_VERSION}/kotatsu-parsers-${PARSERS_VERSION}.pom"
           for i in $(seq 1 10); do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,18 +195,18 @@ jobs:
         TAG="v${{ inputs.version_name }}"
         NOTES_FILE="release_notes.md"
 
-        cat > "$NOTES_FILE" <<'EOF'
-        ## DropSauce v${{ inputs.version_name }}
+        cat > "$NOTES_FILE" <<EOF
+## DropSauce v${{ inputs.version_name }}
 
-        ### Installation Instructions
-        1. Download and install the apk file first
-        2. go to the Explore menu> Manage and click the pen icon to add an extension repo
-        3. install and use the extensions, read, add items to the favorites and ENJOY!
-        If this is your first time using the app, I recommend uninstalling any extension you find when opening the app for the first time and then installing latest extensions from your preferred repository"
+### Installation Instructions
+1. Download and install the apk file first
+2. go to the Explore menu> Manage and click the pen icon to add an extension repo
+3. install and use the extensions, read, add items to the favorites and ENJOY!
+If this is your first time using the app, I recommend uninstalling any extension you find when opening the app for the first time and then installing latest extensions from your preferred repository
 
-        ### Changelog
-        ${{ steps.changelog.outputs.changelog }}
-        EOF
+### Changelog
+${{ steps.changelog.outputs.changelog }}
+EOF
 
         gh release create "$TAG" release/*.apk \
           --title "$TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
         TAG="v${{ inputs.version_name }}"
         NOTES_FILE="release_notes.md"
 
-        cat > "$NOTES_FILE" <<EOF
+        cat > "$NOTES_FILE" <<'EOF'
 ## DropSauce v${{ inputs.version_name }}
 
 ### Installation Instructions

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,14 +71,10 @@ android {
 	}
 	packaging {
 		resources {
-			//noinspection GrDeprecatedAPIUsage
-			exclude 'META-INF/README.md'
-			//noinspection GrDeprecatedAPIUsage
-			exclude 'META-INF/NOTICE.md'
+			excludes += ['META-INF/README.md', 'META-INF/NOTICE.md']
 		}
 		jniLibs {
-			// GitHub releases are universal APKs, so compress native libraries to avoid
-			// shipping every ABI at its full on-disk size. Android extracts them at install.
+			// Keep native libraries uncompressed so they don't need extraction at install.
 			useLegacyPackaging = true
 			keepDebugSymbols += [
 				'**/libandroidx.graphics.path.so',
@@ -168,8 +164,7 @@ kotlin {
 }
 
 dependencies {
-	//noinspection UseTomlInstead
-	implementation("com.github.YakaTeam:kotatsu-parsers:${libs.versions.parsers.get()}") {
+	implementation(libs.kotatsu.parsers) {
 		exclude group: 'org.json', module: 'json'
 	}
 
@@ -241,9 +236,7 @@ dependencies {
 	implementation libs.xmlutil.serialization
 
 	implementation libs.adapterdelegates
-	implementation(libs.adapterdelegates.viewbinding) {
-		exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
-	}
+	implementation libs.adapterdelegates.viewbinding
 
 	implementation libs.hilt.android
 	ksp libs.hilt.compiler

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Sat Sep 19 17:19:33 EEST 2020
-android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,7 @@ play-services-auth = { module = "com.google.android.gms:play-services-auth", ver
 rxjava = { module = "io.reactivex:rxjava", version.ref = "rxjava" }
 unifile = { module = "com.github.tachiyomiorg:unifile", version.ref = "unifile" }
 injekt-core = { module = "com.github.null2264.injekt:injekt-core", version.ref = "injekt" }
+kotatsu-parsers = { module = "com.github.YakaTeam:kotatsu-parsers", version.ref = "parsers" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 ssiv = { module = "com.github.KotatsuApp:subsampling-scale-image-view", version.ref = "ssiv" }
 androidx-window = { module = "androidx.window:window", version.ref = "window" }


### PR DESCRIPTION
## Summary

- **Restore CI on PRs** — Recreated `pr-checks.yml` that runs Android lint on push/PR to `main` (was deleted in a previous commit). Uploads SARIF for code scanning when possible.
- **Fix broken release heredoc** — The release notes heredoc in `release.yml` used `<<'EOF'` with an indented closing `EOF`. Bash never recognized the terminator, so release notes were malformed. Fixed by removing the indentation from the closing delimiter.
- **Align GitHub Actions versions** — Updated `actions/checkout`, `setup-java`, and `upload-artifact` from `@v4` to `@v5` across all workflows for consistency.
- **Fix incorrect comment** — The `useLegacyPackaging = true` comment said "compress native libraries" but the setting does the opposite. Corrected the comment to match the actual behavior.
- **Migrate deprecated API** — Replaced deprecated `exclude` calls with `excludes +=` in the packaging block, removing the associated `noinspection` suppressions.
- **Migrate parsers dependency to version catalog** — Moved the `kotatsu-parsers` dependency from an inline string to a proper `libs.versions.toml` entry, removing the `noinspection UseTomlInstead` suppression.
- **Remove dead excludes** — Removed the `kotlin-android-extensions-runtime` exclude from `adapterdelegates-viewbinding` (module was removed in Kotlin 1.8+).
- **Remove no-op config** — Removed `android.enableJetifier=false` from `gradle.properties` (no-op in AGP 9.x).

## Changes

- **New:** `.github/workflows/pr-checks.yml` — lint on push/PR
- **Modified:** `.github/workflows/preview-build.yml` — Actions `@v4` to `@v5`
- **Modified:** `.github/workflows/release.yml` — Fixed heredoc terminator
- **Modified:** `app/build.gradle` — Fixed comment, migrated deprecated API, removed dead excludes
- **Modified:** `gradle.properties` — Removed no-op Jetifier config
- **Modified:** `gradle/libs.versions.toml` — Added `kotatsu-parsers` library entry

## Testing

- All changes are build configuration — no runtime behavior changes
- The `useLegacyPackaging` setting is unchanged (still `true`), only the comment was corrected
- CI workflow is additive and non-blocking (`continue-on-error: true` on lint)