### PR TITLE
refactor: extract PaginationDelegate and Compose boilerplate

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/list/FavouritesListViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/favourites/ui/list/FavouritesListViewModel.kt
@@ -31,6 +31,7 @@ import org.koitharu.kotatsu.history.domain.MarkAsReadUseCase
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 import org.koitharu.kotatsu.list.domain.ListSortOrder
 import org.koitharu.kotatsu.list.domain.MangaListMapper
+import org.koitharu.kotatsu.list.domain.PaginationDelegate
 import org.koitharu.kotatsu.list.domain.QuickFilterListener
 import org.koitharu.kotatsu.list.ui.MangaListViewModel
 import org.koitharu.kotatsu.list.ui.model.EmptyState
@@ -42,13 +43,10 @@ import org.koitharu.kotatsu.list.ui.model.MangaListModel
 import org.koitharu.kotatsu.list.ui.model.LoadingState
 import org.koitharu.kotatsu.list.ui.model.toErrorState
 import org.koitharu.kotatsu.parsers.model.Manga
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import org.koitharu.kotatsu.local.data.LocalStorageChanges
 import org.koitharu.kotatsu.local.domain.model.LocalManga
 import kotlinx.coroutines.flow.SharedFlow
-
-private const val PAGE_SIZE = 16
 
 @HiltViewModel
 class FavouritesListViewModel @Inject constructor(
@@ -65,8 +63,7 @@ class FavouritesListViewModel @Inject constructor(
 	val categoryId: Long = savedStateHandle[AppRouter.KEY_ID] ?: NO_ID
 	private val quickFilter = quickFilterFactory.create(categoryId)
 	private val refreshTrigger = MutableStateFlow(Any())
-	private val limit = MutableStateFlow(PAGE_SIZE)
-	private val isPaginationReady = AtomicBoolean(false)
+	private val pagination = PaginationDelegate()
 
 	override val listMode = settings.observeAsFlow(AppSettings.KEY_LIST_MODE_FAVORITES) { favoritesListMode }
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, settings.favoritesListMode)
@@ -100,7 +97,7 @@ class FavouritesListViewModel @Inject constructor(
 	) { list, filters, mode, _, pinned ->
 		list.mapList(mode, filters, pinned.takeIfDefaultState(filters))
 	}.distinctUntilChanged().onEach {
-		isPaginationReady.set(true)
+		pagination.onContentReady()
 	}.catch {
 		emit(listOf(it.toErrorState(canRetry = false)))
 	}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, listOf(LoadingState))
@@ -149,9 +146,7 @@ class FavouritesListViewModel @Inject constructor(
 	}
 
 	fun requestMoreItems() {
-		if (isPaginationReady.compareAndSet(true, false)) {
-			limit.value += PAGE_SIZE
-		}
+		pagination.requestMoreItems()
 	}
 
 	private suspend fun List<Manga>.mapList(
@@ -201,18 +196,19 @@ class FavouritesListViewModel @Inject constructor(
 		combine(
 			sortOrder.filterNotNull(),
 			quickFilter.appliedOptions.combineWithSettings(),
-			limit,
+			pagination.limit,
 			pinnedIds,
 		) { order, filters, limit, pinned ->
-			isPaginationReady.set(false)
+			pagination.onQueryLaunched()
 			repository.observeAll(order, filters, limit, pinned.takeIfDefaultState(filters))
 		}.flattenLatest()
 	} else {
 		combine(
 			quickFilter.appliedOptions.combineWithSettings(),
-			limit,
+			pagination.limit,
 			pinnedIds,
 		) { filters, limit, pinned ->
+			pagination.onQueryLaunched()
 			repository.observeAll(categoryId, filters, limit, pinned.takeIfDefaultState(filters))
 		}.flattenLatest()
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/history/ui/HistoryListViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/history/ui/HistoryListViewModel.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu.history.ui
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -30,6 +29,7 @@ import org.koitharu.kotatsu.history.domain.model.MangaWithHistory
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 import org.koitharu.kotatsu.list.domain.ListSortOrder
 import org.koitharu.kotatsu.list.domain.MangaListMapper
+import org.koitharu.kotatsu.list.domain.PaginationDelegate
 import org.koitharu.kotatsu.list.domain.QuickFilterListener
 import org.koitharu.kotatsu.list.domain.ReadingProgress
 import org.koitharu.kotatsu.list.ui.MangaListViewModel
@@ -41,13 +41,10 @@ import org.koitharu.kotatsu.list.ui.model.LoadingState
 import org.koitharu.kotatsu.list.ui.model.toErrorState
 import org.koitharu.kotatsu.parsers.model.Manga
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import org.koitharu.kotatsu.local.data.LocalStorageChanges
 import org.koitharu.kotatsu.local.domain.model.LocalManga
 import kotlinx.coroutines.flow.SharedFlow
-
-private const val PAGE_SIZE = 16
 
 @HiltViewModel
 class HistoryListViewModel @Inject constructor(
@@ -79,8 +76,7 @@ class HistoryListViewModel @Inject constructor(
 		g && s.isGroupingSupported()
 	}
 
-	private val limit = MutableStateFlow(PAGE_SIZE)
-	private val isPaginationReady = AtomicBoolean(false)
+	private val pagination = PaginationDelegate()
 
 	val isStatsEnabled = settings.observeAsStateFlow(
 		scope = viewModelScope + Dispatchers.Default,
@@ -97,7 +93,7 @@ class HistoryListViewModel @Inject constructor(
 	) { filters, list, grouped, mode, incognito ->
 		mapList(list, grouped, mode, filters, incognito)
 	}.distinctUntilChanged().onEach {
-		isPaginationReady.set(true)
+		pagination.onContentReady()
 	}.catch { e ->
 		emit(listOf(e.toErrorState(canRetry = false)))
 	}.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, listOf(LoadingState))
@@ -143,17 +139,15 @@ class HistoryListViewModel @Inject constructor(
 	}
 
 	fun requestMoreItems() {
-		if (isPaginationReady.compareAndSet(true, false)) {
-			limit.value += PAGE_SIZE
-		}
+		pagination.requestMoreItems()
 	}
 
 	private fun observeHistory() = combine(
 		sortOrder,
 		quickFilter.appliedOptions.combineWithSettings(),
-		limit,
+		pagination.limit,
 	) { order, filters, limit ->
-		isPaginationReady.set(false)
+		pagination.onQueryLaunched()
 		repository.observeAllWithHistory(order, filters, limit)
 	}.flattenLatest()
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/PaginationDelegate.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/domain/PaginationDelegate.kt
@@ -1,0 +1,28 @@
+package org.koitharu.kotatsu.list.domain
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.util.concurrent.atomic.AtomicBoolean
+
+class PaginationDelegate(private val pageSize: Int = DEFAULT_PAGE_SIZE) {
+
+	val limit = MutableStateFlow(pageSize)
+	private val isReady = AtomicBoolean(false)
+
+	fun requestMoreItems() {
+		if (isReady.compareAndSet(true, false)) {
+			limit.value += pageSize
+		}
+	}
+
+	fun onQueryLaunched() {
+		isReady.set(false)
+	}
+
+	fun onContentReady() {
+		isReady.set(true)
+	}
+
+	companion object {
+		const val DEFAULT_PAGE_SIZE = 16
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/AppearanceSettingsFragment.kt
@@ -6,9 +6,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings as SystemSettings
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
@@ -25,9 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -52,7 +48,6 @@ import org.koitharu.kotatsu.parsers.util.toTitleCase
 import org.koitharu.kotatsu.settings.appearance.PreviewSettingsFragment
 import org.koitharu.kotatsu.settings.compose.BaseComposeSettingsFragment
 import org.koitharu.kotatsu.settings.compose.ColorSchemePickerRow
-import org.koitharu.kotatsu.settings.compose.DropSauceTheme
 import org.koitharu.kotatsu.settings.compose.ListSettingsItem
 import org.koitharu.kotatsu.settings.compose.MultiSelectSettingsItem
 import org.koitharu.kotatsu.settings.compose.NavigationSettingsItem
@@ -101,38 +96,30 @@ class AppearanceSettingsFragment : BaseComposeSettingsFragment(R.string.appearan
 		}
 	}
 
-	override fun onCreateView(
-		inflater: LayoutInflater,
-		container: ViewGroup?,
-		savedInstanceState: Bundle?,
-	): View = ComposeView(requireContext()).apply {
-		setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-		setContent {
-			DropSauceTheme {
-				val authOk by authSupported.asStateFlow().collectAsState()
-				AppearanceScreen(
-					authSupported = authOk,
-					dynamicShortcutsAvailable = appShortcutManager.isDynamicShortcutsAvailable(),
-					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
-					onOpenLocaleSettings = ::openSystemLocaleSettings,
-					onOpenDetailsAppearance = {
-						(activity as? SettingsActivity)?.openFragment(
-							PreviewSettingsFragment::class.java,
-							null,
-							isFromRoot = false,
-						)
-					},
-					onOpenNavConfig = {
-						(activity as? SettingsActivity)?.openFragment(
-							NavConfigFragment::class.java,
-							null,
-							isFromRoot = false,
-						)
-					},
-					onRequestProtectAuth = ::startProtectionAuthentication,
+	@Composable
+	override fun Content() {
+		val authOk by authSupported.asStateFlow().collectAsState()
+		AppearanceScreen(
+			authSupported = authOk,
+			dynamicShortcutsAvailable = appShortcutManager.isDynamicShortcutsAvailable(),
+			onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
+			onOpenLocaleSettings = ::openSystemLocaleSettings,
+			onOpenDetailsAppearance = {
+				(activity as? SettingsActivity)?.openFragment(
+					PreviewSettingsFragment::class.java,
+					null,
+					isFromRoot = false,
 				)
-			}
-		}
+			},
+			onOpenNavConfig = {
+				(activity as? SettingsActivity)?.openFragment(
+					NavConfigFragment::class.java,
+					null,
+					isFromRoot = false,
+				)
+			},
+			onRequestProtectAuth = ::startProtectionAuthentication,
+		)
 	}
 
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/DownloadsSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/DownloadsSettingsFragment.kt
@@ -7,9 +7,8 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings as SystemSettings
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,12 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -53,7 +50,6 @@ import org.koitharu.kotatsu.local.data.LocalStorageManager
 import org.koitharu.kotatsu.parsers.util.names
 import org.koitharu.kotatsu.settings.compose.ActionSettingsItem
 import org.koitharu.kotatsu.settings.compose.BaseComposeSettingsFragment
-import org.koitharu.kotatsu.settings.compose.DropSauceTheme
 import org.koitharu.kotatsu.settings.compose.ListSettingsItem
 import org.koitharu.kotatsu.settings.compose.PlainInfoSettingsItem
 import org.koitharu.kotatsu.settings.compose.SettingsGroup
@@ -76,7 +72,6 @@ import org.koitharu.kotatsu.core.util.ext.toFileNameSafe
 import org.koitharu.kotatsu.parsers.util.nullIfEmpty
 import org.koitharu.kotatsu.parsers.util.runCatchingCancellable
 import org.koitharu.kotatsu.core.ui.dialog.buildAlertDialog
-import android.widget.Toast
 import java.io.File
 import org.json.JSONObject
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -129,29 +124,21 @@ class DownloadsSettingsFragment :
 		dozeAvailable.value = isDozeIgnoreAvailable()
 	}
 
-	override fun onCreateView(
-		inflater: LayoutInflater,
-		container: ViewGroup?,
-		savedInstanceState: Bundle?,
-	): View = ComposeView(requireContext()).apply {
-		setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-		setContent {
-			DropSauceTheme {
-				DownloadsScreen(
-					storageSummary = storageSummary.asStateFlow(),
-					directoryCount = directoryCount.asStateFlow(),
-					pagesDirSummary = pagesDirSummary.asStateFlow(),
-					dozeAvailable = dozeAvailable.asStateFlow(),
-					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
-					onPickLocalManga = { router.openDirectoriesSettings() },
-					onPickLocalStorage = { router.showDirectorySelectDialog() },
-					onMeteredChanged = { updateDownloadsConstraints() },
-					onPickPagesDir = ::launchPagesDirPicker,
-					onIgnoreDoze = ::startIgnoreDoseActivity,
-					onRebuildDownloadsIndex = ::rebuildDownloadsIndex,
-				)
-			}
-		}
+	@Composable
+	override fun Content() {
+		DownloadsScreen(
+			storageSummary = storageSummary.asStateFlow(),
+			directoryCount = directoryCount.asStateFlow(),
+			pagesDirSummary = pagesDirSummary.asStateFlow(),
+			dozeAvailable = dozeAvailable.asStateFlow(),
+			onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
+			onPickLocalManga = { router.openDirectoriesSettings() },
+			onPickLocalStorage = { router.showDirectorySelectDialog() },
+			onMeteredChanged = { updateDownloadsConstraints() },
+			onPickPagesDir = ::launchPagesDirPicker,
+			onIgnoreDoze = ::startIgnoreDoseActivity,
+			onRebuildDownloadsIndex = ::rebuildDownloadsIndex,
+		)
 	}
 
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/ReaderSettingsFragment.kt
@@ -2,9 +2,6 @@ package org.koitharu.kotatsu.settings
 
 import android.content.pm.ActivityInfo
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,9 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,7 +29,6 @@ import org.koitharu.kotatsu.parsers.util.names
 import org.koitharu.kotatsu.settings.compose.ActionSettingsItem
 import org.koitharu.kotatsu.settings.compose.CategoryPalette
 import org.koitharu.kotatsu.settings.compose.BaseComposeSettingsFragment
-import org.koitharu.kotatsu.settings.compose.DropSauceTheme
 import org.koitharu.kotatsu.settings.compose.ListSettingsItem
 import org.koitharu.kotatsu.settings.compose.MultiSelectSettingsItem
 import org.koitharu.kotatsu.settings.compose.SettingsGroup
@@ -52,25 +46,13 @@ class ReaderSettingsFragment : BaseComposeSettingsFragment(R.string.reader_setti
 	@Inject
 	lateinit var activityRecreationHandle: ActivityRecreationHandle
 
-	override fun onCreateView(
-		inflater: LayoutInflater,
-		container: ViewGroup?,
-		savedInstanceState: Bundle?,
-	): View = ComposeView(requireContext()).apply {
-		setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-		setContent {
-			DropSauceTheme {
-				ReaderScreen(
-					onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
-					onTapActions = router::openReaderTapGridSettings,
-					onTitleTapToReadChanged = { activityRecreationHandle.recreateAll() },
-				)
-			}
-		}
-	}
-
-	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-		super.onViewCreated(view, savedInstanceState)
+	@Composable
+	override fun Content() {
+		ReaderScreen(
+			onBack = { requireActivity().onBackPressedDispatcher.onBackPressed() },
+			onTapActions = router::openReaderTapGridSettings,
+			onTitleTapToReadChanged = { activityRecreationHandle.recreateAll() },
+		)
 	}
 
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/BaseComposeSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/compose/BaseComposeSettingsFragment.kt
@@ -1,7 +1,13 @@
 package org.koitharu.kotatsu.settings.compose
 
-import androidx.annotation.StringRes
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 
 /**
@@ -13,10 +19,32 @@ import androidx.fragment.app.Fragment
  *   synchronously — no SideEffect race. This guarantees the title displayed in the
  *   activity's toolbar matches the current fragment by the time the user sees the frame
  *   after a back-pop.
+ * - Provides [createComposeView] to eliminate the boilerplate ComposeView +
+ *   ViewCompositionStrategy + DropSauceTheme setup across subclasses.
  */
 abstract class BaseComposeSettingsFragment(
 	@StringRes private val titleId: Int,
 ) : Fragment(), ComposeOwnedScreen {
+
+	override fun onCreateView(
+		inflater: LayoutInflater,
+		container: ViewGroup?,
+		savedInstanceState: Bundle?,
+	): View = createComposeView { Content() }
+
+	@Composable
+	protected open fun Content() = Unit
+
+	protected fun createComposeView(content: @Composable () -> Unit): View {
+		return ComposeView(requireContext()).apply {
+			setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+			setContent {
+				DropSauceTheme {
+					content()
+				}
+			}
+		}
+	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/tracker/ui/feed/FeedViewModel.kt
@@ -26,6 +26,7 @@ import org.koitharu.kotatsu.core.util.ext.call
 import org.koitharu.kotatsu.history.data.HistoryRepository
 import org.koitharu.kotatsu.list.domain.ListFilterOption
 import org.koitharu.kotatsu.list.domain.MangaListMapper
+import org.koitharu.kotatsu.list.domain.PaginationDelegate
 import org.koitharu.kotatsu.list.domain.QuickFilterListener
 import org.koitharu.kotatsu.list.ui.model.EmptyState
 import org.koitharu.kotatsu.list.ui.model.ListHeader
@@ -38,7 +39,6 @@ import org.koitharu.kotatsu.tracker.domain.UpdatesListQuickFilter
 import org.koitharu.kotatsu.tracker.domain.model.TrackingLogItem
 import org.koitharu.kotatsu.tracker.ui.feed.model.FeedItem
 import org.koitharu.kotatsu.tracker.work.TrackWorker
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 private const val PAGE_SIZE = 20
@@ -54,8 +54,7 @@ class FeedViewModel @Inject constructor(
 	private val db: MangaDatabase,
 ) : BaseViewModel(), QuickFilterListener by quickFilter {
 
-	private val limit = MutableStateFlow(PAGE_SIZE)
-	private val isReady = AtomicBoolean(false)
+	private val pagination = PaginationDelegate(PAGE_SIZE)
 	private val expandedIds = MutableStateFlow<Set<Long>>(emptySet())
 
 	val isRunning = scheduler.observeIsRunning()
@@ -70,7 +69,7 @@ class FeedViewModel @Inject constructor(
 	@Suppress("USELESS_CAST")
 	val content = combine(
 		quickFilter.appliedOptions,
-		combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
+		combine(pagination.limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
 			.flatMapLatest { repository.observeTrackingLog(it.first, it.second) },
 		combine(
 			settings.observeAsFlow(AppSettings.KEY_TIPS_CLOSED) { isTipEnabled(TIP_GESTURES) },
@@ -92,7 +91,7 @@ class FeedViewModel @Inject constructor(
 				actionStringRes = 0,
 			)
 		} else {
-			isReady.set(true)
+			pagination.onContentReady()
 			list.mapListTo(result, expanded)
 		}
 		result as List<ListModel>
@@ -117,9 +116,7 @@ class FeedViewModel @Inject constructor(
 	}
 
 	fun requestMoreItems() {
-		if (isReady.compareAndSet(true, false)) {
-			limit.value += PAGE_SIZE
-		}
+		pagination.requestMoreItems()
 	}
 
 	fun update() {


### PR DESCRIPTION
## Summary

- **PaginationDelegate**: New class encapsulating the `AtomicBoolean + MutableStateFlow(PAGE_SIZE)` pagination pattern. Three ViewModels (`HistoryListViewModel`, `FavouritesListViewModel`, `FeedViewModel`) now delegate to it instead of reimplementing identical logic.
- **BaseComposeSettingsFragment.createComposeView()**: Eliminates duplicated `ComposeView + ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed + DropSauceTheme` boilerplate. `AppearanceSettingsFragment`, `ReaderSettingsFragment`, `DownloadsSettingsFragment` refactored to use it.

## Files

- `list/domain/PaginationDelegate.kt` — new
- `history/ui/HistoryListViewModel.kt` — uses PaginationDelegate
- `favourites/ui/list/FavouritesListViewModel.kt` — uses PaginationDelegate
- `tracker/ui/feed/FeedViewModel.kt` — uses PaginationDelegate
- `settings/compose/BaseComposeSettingsFragment.kt` — adds createComposeView()
- `settings/AppearanceSettingsFragment.kt` — uses createComposeView()
- `settings/ReaderSettingsFragment.kt` — uses createComposeView()
- `settings/DownloadsSettingsFragment.kt` — uses createComposeView()