### PR TITLE
feat: auto-fill manga metadata from linked trackers

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigActivity.kt
@@ -82,6 +82,8 @@ class OverrideConfigActivity : BaseActivity<ActivityOverrideEditBinding>(), Acti
 				val density = LocalDensity.current
 				val data by viewModel.data.collectAsState()
 				val isLoading by viewModel.isLoading.collectAsState()
+				val linkedTrackers by viewModel.linkedTrackers.collectAsState()
+				val isFetchingTrackerMetadata by viewModel.isFetchingTrackerMetadata.collectAsState()
 				data?.let { (manga, override) ->
 					OverrideEditScreen(
 						manga = manga,
@@ -95,10 +97,13 @@ class OverrideConfigActivity : BaseActivity<ActivityOverrideEditBinding>(), Acti
 						error = errorText.value,
 						bottomInset = with(density) { bottomInset.intValue.toDp() },
 						imageLoader = coil,
+						linkedTrackers = linkedTrackers,
+						isFetchingTrackerMetadata = isFetchingTrackerMetadata,
 						onTitleChange = { titleText.value = it },
 						onDescriptionChange = { descriptionText.value = it },
 						onCoverPick = ::onCoverPick,
 						onCoverReset = { viewModel.updateCover(null) },
+						onFetchTrackerMetadata = { viewModel.fetchTrackerMetadata(it) },
 					)
 				}
 			}
@@ -111,11 +116,25 @@ class OverrideConfigActivity : BaseActivity<ActivityOverrideEditBinding>(), Acti
 				descriptionText.value = override.description.orEmpty()
 			}
 		}
+		viewModel.onMetadataFetched.observeEvent(this) { metadata ->
+			titleText.value = metadata.title
+			descriptionText.value = metadata.description.orEmpty()
+			Snackbar.make(
+				viewBinding.composeView,
+				getString(R.string.metadata_fetched, getString(metadata.service.titleResId)),
+				Snackbar.LENGTH_SHORT,
+			).show()
+		}
 		viewModel.onSaved.observeEvent(this) {
 			setResult(RESULT_OK)
 			finish()
 		}
 		viewModel.onError.observeEvent(this) { errorText.value = it.getDisplayMessage(resources) }
+	}
+
+	override fun onResume() {
+		super.onResume()
+		viewModel.loadTrackers()
 	}
 
 	override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigActivity.kt
@@ -83,7 +83,7 @@ class OverrideConfigActivity : BaseActivity<ActivityOverrideEditBinding>(), Acti
 				val data by viewModel.data.collectAsState()
 				val isLoading by viewModel.isLoading.collectAsState()
 				val linkedTrackers by viewModel.linkedTrackers.collectAsState()
-				val isFetchingTrackerMetadata by viewModel.isFetchingTrackerMetadata.collectAsState()
+				val fetchingTracker by viewModel.fetchingTracker.collectAsState()
 				data?.let { (manga, override) ->
 					OverrideEditScreen(
 						manga = manga,
@@ -98,7 +98,7 @@ class OverrideConfigActivity : BaseActivity<ActivityOverrideEditBinding>(), Acti
 						bottomInset = with(density) { bottomInset.intValue.toDp() },
 						imageLoader = coil,
 						linkedTrackers = linkedTrackers,
-						isFetchingTrackerMetadata = isFetchingTrackerMetadata,
+						fetchingTracker = fetchingTracker,
 						onTitleChange = { titleText.value = it },
 						onDescriptionChange = { descriptionText.value = it },
 						onCoverPick = ::onCoverPick,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigViewModel.kt
@@ -59,7 +59,7 @@ class OverrideConfigViewModel @Inject constructor(
 	val onMetadataFetched = MutableEventFlow<TrackerMetadata>()
 
 	val linkedTrackers = MutableStateFlow<List<ScrobblerService>>(emptyList())
-	val isFetchingTrackerMetadata = MutableStateFlow(false)
+	val fetchingTracker = MutableStateFlow<ScrobblerService?>(null)
 
 	init {
 		launchLoadingJob(Dispatchers.Default) {
@@ -76,15 +76,14 @@ class OverrideConfigViewModel @Inject constructor(
 			val entities = database.getScrobblingDao().findAll(manga.id)
 			val linked = entities.mapNotNull { entity ->
 				ScrobblerService.entries.find { it.id == entity.scrobbler }
-			}
+			}.distinct()
 			linkedTrackers.value = linked
 		}
 	}
 
 	fun fetchTrackerMetadata(service: ScrobblerService) {
-		if (isFetchingTrackerMetadata.value) return
-		launchLoadingJob(Dispatchers.Default) {
-			isFetchingTrackerMetadata.value = true
+		if (!fetchingTracker.compareAndSet(null, service)) return
+		launchJob(Dispatchers.Default) {
 			try {
 				val scrobbler = scrobblers.find { it.scrobblerService == service }
 					?: throw IllegalStateException(context.getString(R.string.failed_to_fetch_metadata, context.getString(service.titleResId)))
@@ -103,7 +102,7 @@ class OverrideConfigViewModel @Inject constructor(
 					)
 				)
 			} finally {
-				isFetchingTrackerMetadata.value = false
+				fetchingTracker.value = null
 			}
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideConfigViewModel.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import okio.buffer
 import okio.sink
+import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.db.MangaDatabase
 import org.koitharu.kotatsu.core.model.parcelable.ParcelableManga
 import org.koitharu.kotatsu.core.nav.AppRouter
 import org.koitharu.kotatsu.core.parser.MangaDataRepository
@@ -27,22 +29,37 @@ import org.koitharu.kotatsu.core.util.ext.toMimeTypeOrNull
 import org.koitharu.kotatsu.core.util.ext.toUriOrNull
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.util.md5
+import org.koitharu.kotatsu.scrobbling.common.domain.Scrobbler
+import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblerService
 import java.io.File
 import javax.inject.Inject
 
 private const val DIR_COVERS = "covers"
+
+data class TrackerMetadata(
+	val title: String,
+	val description: String?,
+	val coverUrl: String?,
+	val service: ScrobblerService,
+)
 
 @HiltViewModel
 class OverrideConfigViewModel @Inject constructor(
 	savedStateHandle: SavedStateHandle,
 	@ApplicationContext private val context: Context,
 	private val dataRepository: MangaDataRepository,
+	private val database: MangaDatabase,
+	private val scrobblers: Set<@JvmSuppressWildcards Scrobbler>,
 ) : BaseViewModel() {
 
-	private val manga = savedStateHandle.require<ParcelableManga>(AppRouter.KEY_MANGA).manga
+	val manga = savedStateHandle.require<ParcelableManga>(AppRouter.KEY_MANGA).manga
 
 	val data = MutableStateFlow<Pair<Manga, MangaOverride>?>(null)
 	val onSaved = MutableEventFlow<Unit>()
+	val onMetadataFetched = MutableEventFlow<TrackerMetadata>()
+
+	val linkedTrackers = MutableStateFlow<List<ScrobblerService>>(emptyList())
+	val isFetchingTrackerMetadata = MutableStateFlow(false)
 
 	init {
 		launchLoadingJob(Dispatchers.Default) {
@@ -50,6 +67,44 @@ class OverrideConfigViewModel @Inject constructor(
 			// source title/cover, regardless of whether the caller already had an override applied.
 			val sourceManga = dataRepository.findMangaById(manga.id, false) ?: manga
 			data.value = sourceManga to (dataRepository.getOverride(manga.id) ?: emptyOverride())
+			loadTrackers()
+		}
+	}
+
+	fun loadTrackers() {
+		launchJob(Dispatchers.Default) {
+			val entities = database.getScrobblingDao().findAll(manga.id)
+			val linked = entities.mapNotNull { entity ->
+				ScrobblerService.entries.find { it.id == entity.scrobbler }
+			}
+			linkedTrackers.value = linked
+		}
+	}
+
+	fun fetchTrackerMetadata(service: ScrobblerService) {
+		if (isFetchingTrackerMetadata.value) return
+		launchLoadingJob(Dispatchers.Default) {
+			isFetchingTrackerMetadata.value = true
+			try {
+				val scrobbler = scrobblers.find { it.scrobblerService == service }
+					?: throw IllegalStateException(context.getString(R.string.failed_to_fetch_metadata, context.getString(service.titleResId)))
+				val info = scrobbler.getScrobblingInfoOrNull(manga.id)
+					?: throw IllegalStateException(context.getString(R.string.failed_to_fetch_metadata, context.getString(service.titleResId)))
+
+				if (!info.coverUrl.isNullOrBlank()) {
+					updateCover(info.coverUrl)
+				}
+				onMetadataFetched.call(
+					TrackerMetadata(
+						title = info.title,
+						description = info.description?.toString()?.trim(),
+						coverUrl = info.coverUrl,
+						service = service,
+					)
+				)
+			} finally {
+				isFetchingTrackerMetadata.value = false
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideEditScreen.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideEditScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -75,7 +76,7 @@ fun OverrideEditScreen(
 	bottomInset: Dp,
 	imageLoader: ImageLoader,
 	linkedTrackers: List<ScrobblerService>,
-	isFetchingTrackerMetadata: Boolean,
+	fetchingTracker: ScrobblerService?,
 	onTitleChange: (String) -> Unit,
 	onDescriptionChange: (String) -> Unit,
 	onCoverPick: (CoverSource) -> Unit,
@@ -108,7 +109,7 @@ fun OverrideEditScreen(
 		TrackerMetadataSection(
 			linkedTrackers = linkedTrackers,
 			enabled = !isLoading,
-			isFetching = isFetchingTrackerMetadata,
+			fetchingTracker = fetchingTracker,
 			onFetch = onFetchTrackerMetadata,
 		)
 		SectionLabel(stringResource(R.string.change_cover))
@@ -395,7 +396,7 @@ private fun HintRow(text: String) {
 private fun TrackerMetadataSection(
 	linkedTrackers: List<ScrobblerService>,
 	enabled: Boolean,
-	isFetching: Boolean,
+	fetchingTracker: ScrobblerService?,
 	onFetch: (ScrobblerService) -> Unit,
 ) {
 	if (linkedTrackers.isEmpty()) {
@@ -406,8 +407,8 @@ private fun TrackerMetadataSection(
 		linkedTrackers.forEach { service ->
 			TrackerFetchTile(
 				service = service,
-				enabled = enabled && !isFetching,
-				isFetching = isFetching,
+				enabled = enabled && fetchingTracker == null,
+				isFetching = fetchingTracker == service,
 				onClick = { onFetch(service) },
 			)
 		}
@@ -431,7 +432,11 @@ private fun TrackerFetchTile(
 	) {
 		Row(
 			modifier = Modifier
-				.clickable(enabled = enabled, onClick = onClick)
+				.clickable(
+					enabled = enabled,
+					role = Role.Button,
+					onClick = onClick,
+				)
 				.fillMaxWidth()
 				.padding(vertical = 14.dp, horizontal = 16.dp),
 			horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideEditScreen.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/override/OverrideEditScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -53,6 +54,7 @@ import org.koitharu.kotatsu.core.util.ext.mangaSourceExtra
 import org.koitharu.kotatsu.core.util.ext.stableMangaCoverKey
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.util.ifNullOrEmpty
+import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblerService
 
 /**
  * Manga override editor: pick a cover, then optionally retitle and rewrite the description.
@@ -72,10 +74,13 @@ fun OverrideEditScreen(
 	error: String?,
 	bottomInset: Dp,
 	imageLoader: ImageLoader,
+	linkedTrackers: List<ScrobblerService>,
+	isFetchingTrackerMetadata: Boolean,
 	onTitleChange: (String) -> Unit,
 	onDescriptionChange: (String) -> Unit,
 	onCoverPick: (CoverSource) -> Unit,
 	onCoverReset: () -> Unit,
+	onFetchTrackerMetadata: (ScrobblerService) -> Unit,
 ) {
 	val hasCustomCover = !coverUrl.isNullOrEmpty()
 	val imeInset = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
@@ -100,6 +105,12 @@ fun OverrideEditScreen(
 			onResetClick = onCoverReset,
 		)
 		Spacer(Modifier.height(16.dp))
+		TrackerMetadataSection(
+			linkedTrackers = linkedTrackers,
+			enabled = !isLoading,
+			isFetching = isFetchingTrackerMetadata,
+			onFetch = onFetchTrackerMetadata,
+		)
 		SectionLabel(stringResource(R.string.change_cover))
 		CoverSourceGrid(enabled = !isLoading, onPick = onCoverPick)
 		Spacer(Modifier.height(24.dp))
@@ -377,5 +388,97 @@ private fun HintRow(text: String) {
 			style = MaterialTheme.typography.bodySmall,
 			color = MaterialTheme.colorScheme.onSurfaceVariant,
 		)
+	}
+}
+
+@Composable
+private fun TrackerMetadataSection(
+	linkedTrackers: List<ScrobblerService>,
+	enabled: Boolean,
+	isFetching: Boolean,
+	onFetch: (ScrobblerService) -> Unit,
+) {
+	if (linkedTrackers.isEmpty()) {
+		return
+	}
+	SectionLabel(stringResource(R.string.tracker_metadata))
+	Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+		linkedTrackers.forEach { service ->
+			TrackerFetchTile(
+				service = service,
+				enabled = enabled && !isFetching,
+				isFetching = isFetching,
+				onClick = { onFetch(service) },
+			)
+		}
+	}
+	Spacer(Modifier.height(24.dp))
+}
+
+@Composable
+private fun TrackerFetchTile(
+	service: ScrobblerService,
+	enabled: Boolean,
+	isFetching: Boolean,
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Surface(
+		modifier = modifier.fillMaxWidth(),
+		shape = RoundedCornerShape(20.dp),
+		color = MaterialTheme.colorScheme.surfaceContainer,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+	) {
+		Row(
+			modifier = Modifier
+				.clickable(enabled = enabled, onClick = onClick)
+				.fillMaxWidth()
+				.padding(vertical = 14.dp, horizontal = 16.dp),
+			horizontalArrangement = Arrangement.SpaceBetween,
+			verticalAlignment = Alignment.CenterVertically,
+		) {
+			Row(
+				verticalAlignment = Alignment.CenterVertically,
+				modifier = Modifier.weight(1f),
+			) {
+				Icon(
+					painter = painterResource(service.iconResId),
+					contentDescription = null,
+					tint = MaterialTheme.colorScheme.primary,
+					modifier = Modifier.size(24.dp),
+				)
+				Spacer(Modifier.width(14.dp))
+				Column {
+					Text(
+						text = stringResource(R.string.fetch_from_tracker_format, stringResource(service.titleResId)),
+						style = MaterialTheme.typography.labelLarge,
+						fontWeight = FontWeight.SemiBold,
+						maxLines = 1,
+						overflow = TextOverflow.Ellipsis,
+					)
+					Text(
+						text = stringResource(R.string.fetch_tracker_metadata_summary),
+						style = MaterialTheme.typography.bodySmall,
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
+						maxLines = 1,
+						overflow = TextOverflow.Ellipsis,
+					)
+				}
+			}
+			Spacer(Modifier.width(8.dp))
+			if (isFetching) {
+				CircularProgressIndicator(
+					modifier = Modifier.size(20.dp),
+					strokeWidth = 2.dp,
+				)
+			} else {
+				Icon(
+					painter = painterResource(R.drawable.ic_cloud_sync),
+					contentDescription = stringResource(R.string.fetch_from_tracker_format, stringResource(service.titleResId)),
+					tint = MaterialTheme.colorScheme.primary,
+					modifier = Modifier.size(22.dp),
+				)
+			}
+		}
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1128,6 +1128,11 @@
     <string name="cover_source_file">Image file</string>
     <string name="cover_source_page">Manga page</string>
     <string name="cover_source_url">Write URL</string>
+    <string name="tracker_metadata">Tracker metadata</string>
+    <string name="fetch_from_tracker_format">Fetch from %s</string>
+    <string name="fetch_tracker_metadata_summary">Auto-fill title, description and cover</string>
+    <string name="metadata_fetched">Metadata loaded from %s</string>
+    <string name="failed_to_fetch_metadata">Failed to fetch metadata from %s</string>
     <string name="page_switch_timer">The page will switch every ~%d seconds</string>
     <string name="dont_ask_again">Don\'t ask again</string>
     <string name="incognito_mode_hint_nsfw">This manga may contain adult content. Do you want to use incognito mode?</string>


### PR DESCRIPTION
## Summary

Closes #152

Allows users editing manga overrides to fetch and auto-fill metadata (Title, Description, and Cover Art) directly from any linked tracking service (AniList, MyAnimeList, Kitsu, Shikimori, MangaBaka).

### Key Highlights

- **Zero visual change for unlinked manga:** If a manga does not have any linked tracking services, no new sections, cards, or spacers are displayed. The edit screen remains 100% visually identical to `main`.
- **Seamless 1-tap auto-fill:** When a manga is linked to one or more trackers, a compact Material 3 Expressive tile appears above the cover options showing the tracker icon, localized *"Fetch from [Tracker]"* action, and an inline progress indicator while fetching.
- **Review before saving:** Tapping the tracker action updates the cover preview, pre-fills the Title and Description fields, and displays a confirmation Snackbar. Users can review, adjust, or tweak any field before pressing Save.
- **Robust error handling:** Network timeouts or tracker errors are safely caught and surfaced via the standard `BaseViewModel.onError` flow without crashes.

## Changes

- `OverrideConfigViewModel.kt`:
  - Injected `MangaDatabase` and `Set<Scrobbler>` via Hilt.
  - Added `loadTrackers()` to read linked tracker services from `ScrobblingDao`.
  - Added `fetchTrackerMetadata(service)` to asynchronously load `ScrobblerMangaInfo` and update the draft cover and text fields.
- `OverrideEditScreen.kt`:
  - Added `TrackerMetadataSection` and `TrackerFetchTile` with Material 3 styling and loading feedback.
  - Only renders when `linkedTrackers` is non-empty.
- `OverrideConfigActivity.kt`:
  - Connected ViewModel tracker flows to Compose.
  - Handled `onMetadataFetched` to update Title and Description text states and show a confirmation Snackbar.
  - Reloads linked trackers in `onResume()`.
- `strings.xml`:
  - Added localized strings for tracker metadata labels and feedback messages.

## Verification

- Tested compilation with Gradle 9.6.1 (`./gradlew compileDebugKotlin`): `BUILD SUCCESSFUL` with zero errors.
- Verified that all existing manual cover picking options (Gallery, File, Manga Page, URL) and revert actions continue to function without regressions.